### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,6 @@ deploy:
   skip_cleanup: true
   github_token: $github_token
   local_dir: build
+  fqdn: app.mchacks.ca
   on:
     branch: master


### PR DESCRIPTION
add our fqdn (full qualified domain name) so that GH Pages deploys to app.mchacks.ca instead of the GitHub.io URL. 