### PR TITLE
Created sidebar that is always displayed on the side

### DIFF
--- a/src/features/Account/ManageAccountContainer.tsx
+++ b/src/features/Account/ManageAccountContainer.tsx
@@ -156,6 +156,7 @@ class ManageAccountContainer extends React.Component<
           currentPage="Profile"
           status={this.state.status}
           confirmed={this.state.accountDetails.confirmed}
+          created={mode === ManageAccountModes.CREATE ? false : undefined}
         />
         <Helmet>
           <title>

--- a/src/features/Account/ManageAccountContainer.tsx
+++ b/src/features/Account/ManageAccountContainer.tsx
@@ -10,10 +10,11 @@ import {
   FormikProps,
   FormikValues,
 } from 'formik';
-import { Account, Auth } from '../../api';
+import { Account, Auth, Hacker } from '../../api';
 import {
   DietaryRestriction,
   FrontendRoute,
+  HackerStatus,
   IAccount,
   Pronouns,
   ShirtSize,
@@ -34,6 +35,7 @@ import {
   input2date,
   isSponsor,
 } from '../../util';
+import Sidebar from '../Sidebar/Sidebar';
 import ConfirmationEmailSentComponent from './ConfirmationEmailSentComponent';
 import getValidationSchema from './validationSchema';
 
@@ -47,6 +49,7 @@ interface IManageAccountContainerState {
   formSubmitted: boolean;
   accountDetails: IAccount;
   oldPassword: string;
+  status: HackerStatus;
   token?: string;
   accountType?: string;
 }
@@ -81,6 +84,7 @@ class ManageAccountContainer extends React.Component<
       },
       oldPassword: '',
       token: getValueFromQuery('token'),
+      status: HackerStatus.HACKER_STATUS_NONE,
     };
     this.renderFormik = this.renderFormik.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
@@ -99,7 +103,17 @@ class ManageAccountContainer extends React.Component<
           ValidationErrorGenerator(e.data);
         }
         // For some reason we could not get self. We should switch our state to CREATE.
-        this.setState({ mode: ManageAccountModes.CREATE });
+        this.setState({
+          mode: ManageAccountModes.CREATE,
+          status: HackerStatus.HACKER_STATUS_NONE,
+        });
+      }
+      try {
+        const res = await Hacker.getSelf();
+        const status = res.data.data.status;
+        this.setState({ status });
+      } catch (e) {
+        // ignore the error
       }
     }
   }
@@ -133,6 +147,11 @@ class ManageAccountContainer extends React.Component<
     const { mode, accountDetails } = this.state;
     return (
       <MaxWidthBox m={'auto'} maxWidth={'500px'}>
+        <Sidebar
+          currentPage="Profile"
+          status={this.state.status}
+          confirmed={this.state.accountDetails.confirmed}
+        />
         <Helmet>
           <title>
             {mode === ManageAccountModes.CREATE ? 'Create' : 'Edit'} Account |

--- a/src/features/Account/ManageAccountContainer.tsx
+++ b/src/features/Account/ManageAccountContainer.tsx
@@ -36,7 +36,7 @@ import {
   isSponsor,
 } from '../../util';
 import Sidebar from '../Sidebar/Sidebar';
-import ConfirmationEmailSentComponent from './ConfirmationEmailSentComponent';
+import StatusPage from '../Status/StatusPage';
 import getValidationSchema from './validationSchema';
 
 export enum ManageAccountModes {
@@ -128,7 +128,12 @@ class ManageAccountContainer extends React.Component<
     switch (mode) {
       case ManageAccountModes.CREATE:
         if (accountDetails.accountType === UserType.UNKNOWN || !token) {
-          return <ConfirmationEmailSentComponent />;
+          return (
+            <StatusPage
+              status={HackerStatus.HACKER_STATUS_NONE}
+              confirmed={false}
+            />
+          );
         } else if (isSponsor(accountDetails)) {
           return <Redirect to={FrontendRoute.CREATE_SPONSOR_PAGE} />;
         } else {

--- a/src/features/Application/ManageApplicationContainer.tsx
+++ b/src/features/Application/ManageApplicationContainer.tsx
@@ -41,6 +41,7 @@ import ResumeComponent from './ResumeComponent';
 import SchoolComponent from './SchoolComponent';
 
 import WithToasterContainer from '../../shared/HOC/withToaster';
+import Sidebar from '../Sidebar/Sidebar';
 
 export enum ManageApplicationModes {
   CREATE,
@@ -120,6 +121,11 @@ class ManageApplicationContainer extends React.Component<
       <Redirect to={FrontendRoute.HOME_PAGE} />
     ) : (
       <MaxWidthBox m={'auto'} maxWidth={'500px'}>
+        <Sidebar
+          currentPage="Application"
+          status={this.state.hackerDetails.status}
+          confirmed={true}
+        />
         <Helmet>
           <title>
             {mode === ManageApplicationModes.CREATE ? 'Create' : 'Edit'}

--- a/src/features/Application/ManageApplicationContainer.tsx
+++ b/src/features/Application/ManageApplicationContainer.tsx
@@ -125,6 +125,7 @@ class ManageApplicationContainer extends React.Component<
           currentPage="Application"
           status={this.state.hackerDetails.status}
           confirmed={true}
+          created={mode === ManageApplicationModes.CREATE ? false : true}
         />
         <Helmet>
           <title>

--- a/src/features/Application/ManageApplicationContainer.tsx
+++ b/src/features/Application/ManageApplicationContainer.tsx
@@ -125,7 +125,6 @@ class ManageApplicationContainer extends React.Component<
           currentPage="Application"
           status={this.state.hackerDetails.status}
           confirmed={true}
-          created={mode === ManageApplicationModes.CREATE ? false : true}
         />
         <Helmet>
           <title>

--- a/src/features/Dashboard/HackerDashboard-old.tsx
+++ b/src/features/Dashboard/HackerDashboard-old.tsx
@@ -34,7 +34,7 @@ import BusIcon from '../../assets/images/dashboard-bus.svg';
 import ConfirmIcon from '../../assets/images/dashboard-confirm.svg';
 import HackPassIcon from '../../assets/images/dashboard-hackpass.svg';
 import TeamIcon from '../../assets/images/dashboard-team.svg';
-import Sidebar from '../../features/Sidebar/Sidebar';
+// import Sidebar from '../../features/Sidebar/Sidebar';
 
 export interface IDashboardState {
   status: HackerStatus;
@@ -96,7 +96,7 @@ class HackerDashboardContainer extends React.Component<{}, IDashboardState> {
         title={`status: ${status.toLowerCase()}`}
         subtitle={!isAppOpen() ? 'Applications are now closed' : undefined}
       >
-        <Sidebar currentPage={'Home'} />
+        {/* <Sidebar currentPage={'Home'} /> */}
       </DashboardView>
     );
   }

--- a/src/features/Dashboard/HackerDashboard.tsx
+++ b/src/features/Dashboard/HackerDashboard.tsx
@@ -1,11 +1,58 @@
 import * as React from 'react';
-import Sidebar from '../Sidebar/Sidebar';
-
+import { Account } from '../../api';
+import Hacker from '../../api/hacker';
+import { HackerStatus, IAccount } from '../../config';
 import WithToasterContainer from '../../shared/HOC/withToaster';
+import { isConfirmed } from '../../util';
+import StatusPage from '../Status/StatusPage';
 
-class HackerDashboardContainer extends React.Component {
+export interface IDashboardState {
+  account: IAccount;
+  status: HackerStatus;
+  confirmed: boolean;
+}
+
+class HackerDashboardContainer extends React.Component<{}, IDashboardState> {
+  constructor(props: {}) {
+    super(props);
+    this.state = {
+      account: Object(),
+      status: HackerStatus.HACKER_STATUS_NONE,
+      confirmed: false,
+    };
+  }
+  public async componentDidMount() {
+    let status;
+    let confirmed = false;
+    let account;
+
+    try {
+      const res = await Account.getSelf();
+      account = res.data.data;
+      this.setState({ account });
+    } catch (e) {
+      // should not set the account if it doesn't exist.
+    }
+    // set hacker status and confirmed status
+    try {
+      const response = await Hacker.getSelf();
+      status = response.data.data.status;
+      this.setState({ status });
+    } catch (e) {
+      if (e.status === 401) {
+        status = HackerStatus.HACKER_STATUS_NONE;
+        this.setState({ status });
+      }
+    }
+    try {
+      confirmed = await isConfirmed();
+      this.setState({ confirmed });
+    } catch (e) {
+      this.setState({ confirmed });
+    }
+  }
   public render() {
-    return <Sidebar currentPage="Home" />;
+    return <StatusPage {...this.state} />;
   }
 }
 

--- a/src/features/Sidebar/Sidebar.tsx
+++ b/src/features/Sidebar/Sidebar.tsx
@@ -14,9 +14,13 @@ interface ISidebarProps {
   currentPage: string;
   confirmed: boolean;
   status: HackerStatus;
+  created?: boolean;
 }
 
 export const Sidebar: React.SFC<ISidebarProps> = (props) => {
+  Sidebar.defaultProps = {
+    created: true,
+  };
   // add 'Team'
   const TabItems: string[] = ['Home', 'Profile', 'Application'];
   const appRoute =
@@ -40,7 +44,7 @@ export const Sidebar: React.SFC<ISidebarProps> = (props) => {
   function hiddenTab(name: string): boolean {
     switch (name) {
       case 'Home':
-        return false;
+        return !props.created;
       case 'Profile':
         return false;
       case 'Application':

--- a/src/features/Sidebar/Sidebar.tsx
+++ b/src/features/Sidebar/Sidebar.tsx
@@ -1,41 +1,80 @@
 import * as React from 'react';
-import { H2, Image } from '../../shared/Elements';
-import SidebarContainer from './SidebarContainer';
-import SidebarItem from './SidebarItem';
-
 import AppIcon from '../../assets/images/sidebar-app.svg';
 import HomeIcon from '../../assets/images/sidebar-home.svg';
 import ProfileIcon from '../../assets/images/sidebar-profile.svg';
-import { PageType } from '../../config';
+import TeamIcon from '../../assets/images/sidebar-team.svg';
+import { FrontendRoute as routes, HackerStatus } from '../../config';
+import { H2, Image, LinkDuo } from '../../shared/Elements';
+import SidebarContainer from './SidebarContainer';
+import SidebarItem from './SidebarItem';
+// import BusIcon from '../../assets/images/sidebar-bus.svg';
+// import { PageType } from '../../config';
 
 interface ISidebarProps {
-  currentPage: PageType;
+  currentPage: string;
+  confirmed: boolean;
+  status: HackerStatus;
 }
 
 export const Sidebar: React.SFC<ISidebarProps> = (props) => {
-  const PageTypeObj: any = {
-    Home: HomeIcon,
-    Profile: ProfileIcon,
-    Application: AppIcon,
-  };
+  // add 'Team'
+  const TabItems: string[] = ['Home', 'Profile', 'Application'];
+  const appRoute =
+    props.status === HackerStatus.HACKER_STATUS_NONE && props.confirmed
+      ? routes.CREATE_APPLICATION_PAGE
+      : routes.EDIT_APPLICATION_PAGE;
+  const route: any[] = [
+    routes.HOME_PAGE,
+    routes.EDIT_ACCOUNT_PAGE,
+    appRoute,
+    routes.TEAM_PAGE,
+  ];
+
+  const PageTypeObj: any[] = [HomeIcon, ProfileIcon, AppIcon, TeamIcon];
 
   const whiteIcon = {
     filter:
       'invert(97%) sepia(100%) saturate(12%) hue-rotate(248deg) contrast(104%) brightness(100) saturate(100%)',
   };
 
+  function hiddenTab(name: string): boolean {
+    switch (name) {
+      case 'Home':
+        return !props.confirmed;
+      case 'Profile':
+        return false;
+      case 'Application':
+        return !props.confirmed;
+      case 'Team':
+        return !(
+          props.confirmed &&
+          (props.status === HackerStatus.HACKER_STATUS_CONFIRMED ||
+            props.status === HackerStatus.HACKER_STATUS_ACCEPTED ||
+            props.status === HackerStatus.HACKER_STATUS_CHECKED_IN)
+        );
+      default:
+        return true;
+    }
+  }
+
   return (
     <SidebarContainer>
-      {Object.keys(PageTypeObj).map((type) => (
-        <SidebarItem currentPage={props.currentPage === type ? true : false}>
-          <Image
-            src={PageTypeObj[type]}
-            style={props.currentPage === type ? whiteIcon : undefined}
-          />
-          <H2 color={props.currentPage === type ? 'white' : '#4d4d4d'}>
-            {type}
-          </H2>
-        </SidebarItem>
+      {TabItems.map((name, index) => (
+        <LinkDuo to={route[index]} key={name}>
+          <SidebarItem
+            currentPage={props.currentPage === name ? true : false}
+            title={name}
+            hidden={hiddenTab(name)}
+          >
+            <Image
+              src={PageTypeObj[index]}
+              style={props.currentPage === name ? whiteIcon : undefined}
+            />
+            <H2 color={props.currentPage === name ? 'white' : '#4d4d4d'}>
+              {name}
+            </H2>
+          </SidebarItem>
+        </LinkDuo>
       ))}
     </SidebarContainer>
   );

--- a/src/features/Sidebar/Sidebar.tsx
+++ b/src/features/Sidebar/Sidebar.tsx
@@ -67,7 +67,11 @@ export const Sidebar: React.SFC<ISidebarProps> = (props) => {
         hiddenTab(name) ? (
           undefined
         ) : (
-          <LinkDuo to={route[index]} key={name}>
+          <LinkDuo
+            to={route[index]}
+            key={name}
+            style={{ textDecoration: 'none' }}
+          >
             <SidebarItem
               currentPage={props.currentPage === name ? true : false}
               title={name}

--- a/src/features/Sidebar/Sidebar.tsx
+++ b/src/features/Sidebar/Sidebar.tsx
@@ -40,7 +40,7 @@ export const Sidebar: React.SFC<ISidebarProps> = (props) => {
   function hiddenTab(name: string): boolean {
     switch (name) {
       case 'Home':
-        return !props.confirmed;
+        return false;
       case 'Profile':
         return false;
       case 'Application':
@@ -59,23 +59,27 @@ export const Sidebar: React.SFC<ISidebarProps> = (props) => {
 
   return (
     <SidebarContainer>
-      {TabItems.map((name, index) => (
-        <LinkDuo to={route[index]} key={name}>
-          <SidebarItem
-            currentPage={props.currentPage === name ? true : false}
-            title={name}
-            hidden={hiddenTab(name)}
-          >
-            <Image
-              src={PageTypeObj[index]}
-              style={props.currentPage === name ? whiteIcon : undefined}
-            />
-            <H2 color={props.currentPage === name ? 'white' : '#4d4d4d'}>
-              {name}
-            </H2>
-          </SidebarItem>
-        </LinkDuo>
-      ))}
+      {TabItems.map((name, index) =>
+        hiddenTab(name) ? (
+          undefined
+        ) : (
+          <LinkDuo to={route[index]} key={name}>
+            <SidebarItem
+              currentPage={props.currentPage === name ? true : false}
+              title={name}
+              hidden={hiddenTab(name)}
+            >
+              <Image
+                src={PageTypeObj[index]}
+                style={props.currentPage === name ? whiteIcon : undefined}
+              />
+              <H2 color={props.currentPage === name ? 'white' : '#4d4d4d'}>
+                {name}
+              </H2>
+            </SidebarItem>
+          </LinkDuo>
+        )
+      )}
     </SidebarContainer>
   );
 };

--- a/src/features/Sidebar/Sidebar.tsx
+++ b/src/features/Sidebar/Sidebar.tsx
@@ -7,6 +7,7 @@ import { FrontendRoute as routes, HackerStatus } from '../../config';
 import { H2, Image, LinkDuo } from '../../shared/Elements';
 import SidebarContainer from './SidebarContainer';
 import SidebarItem from './SidebarItem';
+import theme from '../../shared/Styles/theme';
 // import BusIcon from '../../assets/images/sidebar-bus.svg';
 // import { PageType } from '../../config';
 
@@ -81,7 +82,13 @@ export const Sidebar: React.SFC<ISidebarProps> = (props) => {
                 src={PageTypeObj[index]}
                 style={props.currentPage === name ? whiteIcon : undefined}
               />
-              <H2 color={props.currentPage === name ? 'white' : '#4d4d4d'}>
+              <H2
+                color={
+                  props.currentPage === name
+                    ? theme.colors.white
+                    : theme.colors.black80
+                }
+              >
                 {name}
               </H2>
             </SidebarItem>

--- a/src/features/Sidebar/SidebarContainer.tsx
+++ b/src/features/Sidebar/SidebarContainer.tsx
@@ -8,7 +8,7 @@ export const SidebarContainer = styled.nav`
   height: 100%;
   width: 18%;
   text-align: left;
-  padding: 3rem 0 0 0;
+  padding: 0 0 0 0;
   position: fixed;
   left: 0;
 

--- a/src/features/Sidebar/SidebarContainer.tsx
+++ b/src/features/Sidebar/SidebarContainer.tsx
@@ -9,7 +9,7 @@ export const SidebarContainer = styled.nav`
   width: 18%;
   text-align: left;
   padding: 3rem 0 0 0;
-  position: absolute;
+  position: fixed;
   left: 0;
 
   @media (max-width: 576px) {

--- a/src/features/Sidebar/SidebarContainer.tsx
+++ b/src/features/Sidebar/SidebarContainer.tsx
@@ -1,16 +1,17 @@
 import styled from '../../shared/Styles/styled-components';
+import theme from '../../shared/Styles/theme';
 
 export const SidebarContainer = styled.nav`
   display: flex;
   flex-direction: column;
-  background: #ededed;
-  box-shadow: 3px 0px 5px 6px #e8e8e8;
+  background: ${theme.colors.black5};
+  box-shadow: 3px 0px 5px 3px ${theme.colors.black40};
   transform: 'translateX(-100%)';
   height: 100%;
   width: 18%;
   text-align: left;
   padding: 0 0 0 0;
-  position: absolute;
+  position: fixed;
   left: 0;
   @media (max-width: 576px) {
     width: 100%;

--- a/src/features/Sidebar/SidebarContainer.tsx
+++ b/src/features/Sidebar/SidebarContainer.tsx
@@ -3,15 +3,15 @@ import styled from '../../shared/Styles/styled-components';
 export const SidebarContainer = styled.nav`
   display: flex;
   flex-direction: column;
-  background: #f4f4f4;
+  background: #ededed;
+  box-shadow: 3px 0px 5px 6px #e8e8e8;
   transform: 'translateX(-100%)';
   height: 100%;
   width: 18%;
   text-align: left;
   padding: 0 0 0 0;
-  position: fixed;
+  position: absolute;
   left: 0;
-
   @media (max-width: 576px) {
     width: 100%;
   }

--- a/src/features/Sidebar/SidebarItem.tsx
+++ b/src/features/Sidebar/SidebarItem.tsx
@@ -1,14 +1,16 @@
 import styled from '../../shared/Styles/styled-components';
 
-interface ISidebarItemProps {
+export interface ISidebarItemProps {
   currentPage: boolean;
+  title: string;
+  hidden: boolean;
 }
 
 export const SidebarItem = styled.div<ISidebarItemProps>`
   padding: 1.5rem 0 1rem 2rem;
   display: flex;
-  background-color: ${(props) => (props.currentPage ? '#F2463A' : '')};
-
+  visibility: ${(props) => (props.hidden ? 'hidden' : '')};
+  background-color: ${(props) => (props.currentPage ? '#F2463A' : '#ffffff')};
   img {
     flex-direction: column;
     height: 2rem;

--- a/src/features/Sidebar/SidebarItem.tsx
+++ b/src/features/Sidebar/SidebarItem.tsx
@@ -1,4 +1,5 @@
 import styled from '../../shared/Styles/styled-components';
+import theme from '../../shared/Styles/theme';
 
 export interface ISidebarItemProps {
   currentPage: boolean;
@@ -11,9 +12,11 @@ export const SidebarItem = styled.div<ISidebarItemProps>`
   display: flex;
   position: relative;
   visibility: ${(props) => (props.hidden ? 'hidden' : '')};
-  background-color: ${(props) => (props.currentPage ? '#F2463A' : '#ededed')};
+  background-color: ${(props) =>
+    props.currentPage ? theme.colors.red : '#ededed'};
   :hover {
-    background-color: #ebc634;
+    background-color: ${(props) =>
+      props.currentPage ? '#ededed' : theme.colors.yellow};
   }
   img {
     flex-direction: column;

--- a/src/features/Sidebar/SidebarItem.tsx
+++ b/src/features/Sidebar/SidebarItem.tsx
@@ -9,8 +9,12 @@ export interface ISidebarItemProps {
 export const SidebarItem = styled.div<ISidebarItemProps>`
   padding: 1.5rem 0 1rem 2rem;
   display: flex;
+  position: relative;
   visibility: ${(props) => (props.hidden ? 'hidden' : '')};
-  background-color: ${(props) => (props.currentPage ? '#F2463A' : '#ffffff')};
+  background-color: ${(props) => (props.currentPage ? '#F2463A' : '#ededed')};
+  :hover {
+    background-color: #ebc634;
+  }
   img {
     flex-direction: column;
     height: 2rem;
@@ -20,8 +24,8 @@ export const SidebarItem = styled.div<ISidebarItemProps>`
   h2 {
     padding-left: 35px;
     padding-top: 2px;
-    text-decoration: none;
     transition: color 0.3s linear;
+    text-decoration-line: none;
 
     @media (max-width: 576px) {
       font-size: 1.5rem;

--- a/src/features/Sidebar/SidebarItem.tsx
+++ b/src/features/Sidebar/SidebarItem.tsx
@@ -13,10 +13,10 @@ export const SidebarItem = styled.div<ISidebarItemProps>`
   position: relative;
   visibility: ${(props) => (props.hidden ? 'hidden' : '')};
   background-color: ${(props) =>
-    props.currentPage ? theme.colors.red : '#ededed'};
+    props.currentPage ? theme.colors.red : theme.colors.black5};
   :hover {
     background-color: ${(props) =>
-      props.currentPage ? '#ededed' : theme.colors.yellow};
+      props.currentPage ? theme.colors.red : theme.colors.yellow};
   }
   img {
     flex-direction: column;

--- a/src/features/Status/StatusPage.tsx
+++ b/src/features/Status/StatusPage.tsx
@@ -11,6 +11,7 @@ import Sidebar from '../Sidebar/Sidebar';
 
 import Background from '../../assets/images/statuspage-background.svg';
 import { FrontendRoute, HackerStatus, IAccount } from '../../config';
+import ConfirmationEmailSentComponent from '../Account/ConfirmationEmailSentComponent';
 
 export interface IStatusPageProps {
   account: IAccount;
@@ -27,30 +28,38 @@ class StatusPage extends React.Component<IStatusPageProps, {}> {
           status={this.props.status}
           confirmed={this.props.confirmed}
         />
-        <h1 style={{ color: 'red' }}>Hey {this.props.account.firstName},</h1>
-        {this.props.status !== HackerStatus.HACKER_STATUS_NONE ? (
-          <Flex flexDirection={'rows'} style={{ marginTop: '8em' }}>
-            <H1 textAlign={'center'} display={'inline'}>
-              Your application status is:
-            </H1>
-            <H1 textAlign={'center'} color={'black'} display={'inline'}>
-              {this.props.status}
-            </H1>
-          </Flex>
+        {this.props.confirmed ? (
+          <div>
+            <h1 style={{ color: 'red' }}>
+              Hey {this.props.account.firstName},
+            </h1>
+            {this.props.status !== HackerStatus.HACKER_STATUS_NONE ? (
+              <Flex flexDirection={'rows'} style={{ marginTop: '8em' }}>
+                <H1 textAlign={'center'} display={'inline'}>
+                  Your application status is:
+                </H1>
+                <H1 textAlign={'center'} color={'black'} display={'inline'}>
+                  {this.props.status}
+                </H1>
+              </Flex>
+            ) : (
+              <Flex
+                flexDirection={'column'}
+                style={{ marginTop: '8em' }}
+                alignItems={'center'}
+              >
+                <Paragraph color={'black'} textAlign={'center'}>
+                  Don't forget to submit your application before Saturday
+                  December 31st{' '}
+                </Paragraph>
+                <LinkDuo to={FrontendRoute.CREATE_APPLICATION_PAGE}>
+                  <Button type="button">Apply</Button>
+                </LinkDuo>
+              </Flex>
+            )}
+          </div>
         ) : (
-          <Flex
-            flexDirection={'column'}
-            style={{ marginTop: '8em' }}
-            alignItems={'center'}
-          >
-            <Paragraph color={'black'} textAlign={'center'}>
-              Don't forget to submit your application before Saturday December
-              31st{' '}
-            </Paragraph>
-            <LinkDuo to={FrontendRoute.CREATE_APPLICATION_PAGE}>
-              <Button type="button">Apply</Button>
-            </LinkDuo>
-          </Flex>
+          <ConfirmationEmailSentComponent />
         )}
         <BackgroundImage
           right={'0px'}

--- a/src/features/Status/StatusPage.tsx
+++ b/src/features/Status/StatusPage.tsx
@@ -12,6 +12,7 @@ import Sidebar from '../Sidebar/Sidebar';
 import Background from '../../assets/images/statuspage-background.svg';
 import { FrontendRoute, HackerStatus, IAccount } from '../../config';
 import ConfirmationEmailSentComponent from '../Account/ConfirmationEmailSentComponent';
+import theme from '../../shared/Styles/theme';
 
 export interface IStatusPageProps {
   account?: IAccount;
@@ -30,7 +31,7 @@ class StatusPage extends React.Component<IStatusPageProps, {}> {
         />
         {this.props.confirmed && this.props.account ? (
           <div>
-            <h1 style={{ color: 'red', textAlign: 'center' }}>
+            <h1 style={{ color: theme.colors.red, textAlign: 'center' }}>
               Hey {this.props.account.firstName},
             </h1>
             {this.props.status !== HackerStatus.HACKER_STATUS_NONE ? (
@@ -38,7 +39,11 @@ class StatusPage extends React.Component<IStatusPageProps, {}> {
                 <H1 textAlign={'center'} display={'inline'}>
                   Your application status is:
                 </H1>
-                <H1 textAlign={'center'} color={'black'} display={'inline'}>
+                <H1
+                  textAlign={'center'}
+                  color={theme.colors.black80}
+                  display={'inline'}
+                >
                   {this.props.status}
                 </H1>
               </Flex>
@@ -48,7 +53,7 @@ class StatusPage extends React.Component<IStatusPageProps, {}> {
                 style={{ marginTop: '1em' }}
                 alignItems={'center'}
               >
-                <Paragraph color={'black'} textAlign={'center'}>
+                <Paragraph color={theme.colors.black80} textAlign={'center'}>
                   Don't forget to submit your application before Saturday
                   December 31st{' '}
                 </Paragraph>

--- a/src/features/Status/StatusPage.tsx
+++ b/src/features/Status/StatusPage.tsx
@@ -1,28 +1,57 @@
 import { Flex } from '@rebass/grid';
 import * as React from 'react';
-import { BackgroundImage, Button, H1, Paragraph } from '../../shared/Elements';
+import {
+  BackgroundImage,
+  Button,
+  H1,
+  LinkDuo,
+  Paragraph,
+} from '../../shared/Elements';
 import Sidebar from '../Sidebar/Sidebar';
 
 import Background from '../../assets/images/statuspage-background.svg';
+import { FrontendRoute, HackerStatus, IAccount } from '../../config';
 
-class StatusPage extends React.Component<{}, {}> {
+export interface IStatusPageProps {
+  account: IAccount;
+  status: HackerStatus;
+  confirmed: boolean;
+}
+
+class StatusPage extends React.Component<IStatusPageProps, {}> {
   public render() {
     return (
       <Flex flexDirection={'column'} alignItems={'center'}>
-        <Sidebar currentPage={'Home'} />
-        <Flex flexDirection={'rows'} style={{ marginTop: '8em' }}>
-          <H1 textAlign={'center'} display={'inline'}>
-            Status:
-          </H1>
-          <H1 textAlign={'center'} color={'black'} display={'inline'}>
-            Start your application
-          </H1>
-        </Flex>
-
-        <Paragraph color={'black'} textAlign={'center'}>
-          Don't forget to submit your application before Saturday December 31st{' '}
-        </Paragraph>
-        <Button type="button">Apply</Button>
+        <Sidebar
+          currentPage={'Home'}
+          status={this.props.status}
+          confirmed={this.props.confirmed}
+        />
+        <h1 style={{ color: 'red' }}>Hey {this.props.account.firstName},</h1>
+        {this.props.status !== HackerStatus.HACKER_STATUS_NONE ? (
+          <Flex flexDirection={'rows'} style={{ marginTop: '8em' }}>
+            <H1 textAlign={'center'} display={'inline'}>
+              Your application status is:
+            </H1>
+            <H1 textAlign={'center'} color={'black'} display={'inline'}>
+              {this.props.status}
+            </H1>
+          </Flex>
+        ) : (
+          <Flex
+            flexDirection={'column'}
+            style={{ marginTop: '8em' }}
+            alignItems={'center'}
+          >
+            <Paragraph color={'black'} textAlign={'center'}>
+              Don't forget to submit your application before Saturday December
+              31st{' '}
+            </Paragraph>
+            <LinkDuo to={FrontendRoute.CREATE_APPLICATION_PAGE}>
+              <Button type="button">Apply</Button>
+            </LinkDuo>
+          </Flex>
+        )}
         <BackgroundImage
           right={'0px'}
           bottom={'0px'}

--- a/src/features/Status/StatusPage.tsx
+++ b/src/features/Status/StatusPage.tsx
@@ -30,11 +30,11 @@ class StatusPage extends React.Component<IStatusPageProps, {}> {
         />
         {this.props.confirmed && this.props.account ? (
           <div>
-            <h1 style={{ color: 'red' }}>
+            <h1 style={{ color: 'red', textAlign: 'center' }}>
               Hey {this.props.account.firstName},
             </h1>
             {this.props.status !== HackerStatus.HACKER_STATUS_NONE ? (
-              <Flex flexDirection={'rows'} style={{ marginTop: '8em' }}>
+              <Flex flexDirection={'rows'} style={{ marginTop: '1em' }}>
                 <H1 textAlign={'center'} display={'inline'}>
                   Your application status is:
                 </H1>
@@ -45,7 +45,7 @@ class StatusPage extends React.Component<IStatusPageProps, {}> {
             ) : (
               <Flex
                 flexDirection={'column'}
-                style={{ marginTop: '8em' }}
+                style={{ marginTop: '1em' }}
                 alignItems={'center'}
               >
                 <Paragraph color={'black'} textAlign={'center'}>

--- a/src/features/Status/StatusPage.tsx
+++ b/src/features/Status/StatusPage.tsx
@@ -14,7 +14,7 @@ import { FrontendRoute, HackerStatus, IAccount } from '../../config';
 import ConfirmationEmailSentComponent from '../Account/ConfirmationEmailSentComponent';
 
 export interface IStatusPageProps {
-  account: IAccount;
+  account?: IAccount;
   status: HackerStatus;
   confirmed: boolean;
 }
@@ -28,7 +28,7 @@ class StatusPage extends React.Component<IStatusPageProps, {}> {
           status={this.props.status}
           confirmed={this.props.confirmed}
         />
-        {this.props.confirmed ? (
+        {this.props.confirmed && this.props.account ? (
           <div>
             <h1 style={{ color: 'red' }}>
               Hey {this.props.account.firstName},

--- a/src/features/Team/JoinCreateTeam.tsx
+++ b/src/features/Team/JoinCreateTeam.tsx
@@ -15,7 +15,7 @@ import {
   MaxWidthBox,
 } from '../../shared/Elements';
 
-import { IHacker } from '../../config';
+import { HackerStatus, IHacker } from '../../config';
 
 import Team from '../../api/team';
 import { Form } from '../../shared/Form';
@@ -24,6 +24,7 @@ import {
   Input,
 } from '../../shared/Form/FormikElements';
 import ValidationErrorGenerator from '../../shared/Form/validationErrorGenerator';
+import Sidebar from '../Sidebar/Sidebar';
 import getValidationSchema from './validationSchema';
 
 interface IJoinCreateTeamProps {
@@ -52,6 +53,11 @@ class JoinCreateTeam extends React.Component<
   public render() {
     return (
       <MaxWidthBox maxWidth={'500px'} m={'auto'}>
+        <Sidebar
+          currentPage="Team"
+          status={HackerStatus.HACKER_STATUS_CONFIRMED}
+          confirmed={true}
+        />
         <H1 fontSize={'30px'} marginTop={'0px'} marginLeft={'0px'}>
           Team
         </H1>

--- a/src/features/Team/TeamDescription.tsx
+++ b/src/features/Team/TeamDescription.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 
 import { Box, Flex } from '@rebass/grid';
 
-import { IMemberName, ITeam } from '../../config';
+import { HackerStatus, IMemberName, ITeam } from '../../config';
 import { Button, H1, MaxWidthBox } from '../../shared/Elements';
-
+import Sidebar from '../Sidebar/Sidebar';
 import { TeamView } from './TeamView';
 
 interface ITeamDescriptionProps {
@@ -19,6 +19,11 @@ const TeamDescription: React.StatelessComponent<ITeamDescriptionProps> = (
 ) => {
   return (
     <MaxWidthBox maxWidth={'400px'} mx={[5, 'auto']}>
+      <Sidebar
+        currentPage="Team"
+        status={HackerStatus.HACKER_STATUS_CONFIRMED}
+        confirmed={true}
+      />
       <H1 fontSize={'30px'} marginTop={'0px'} marginLeft={'0px'}>
         Your Team
       </H1>


### PR DESCRIPTION
### Tickets:

- HCK-121

### List of changes:

Implemented sidebar and revamped dashboard layout. It now just returns the status page initially and from there users can navigate to the desired tab using the sidebar.

### Type of change:

Please delete options that aren't relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### How did you do this?

Implementing the Sidebar element in the appropriate elements that require one (i.e. Application, Account, Home, Team containers). 

### Why are you choosing this approach?

Was the quickest approach for immediate deployment.

### Questions for code reviewers?

I might have useless code commented out, heads up.

### PR Checklist:

- [x] Merged `develop` branch (before testing)
- [x] Linted my code locally
- [x] Tested all links in project relevant browsers
- [x] Tested all links on different screen sizes
- [x] Referenced all useful info (issues, tasks, etc)
