### PR TITLE
Update travel and grad year validation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Create changelog with previous releases
 - Add sidebar styling
 - Add button variant prop
+- Add travel application field validation
 
 ### Changed
 
@@ -21,10 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New profile page styling
 - New application page styling and format
 - Update fields: degrees, dietary restrictions, genders, grad years, job interests, majors, pronouns, skills
+- Update graduation year field validation
 
 ### Fixed
 
 - Asterisks for required fields are working now
+
+### Removed
+
+- Remove `needsBus` application field
 
 ## [1.5.1](https://github.com/hackmcgill/dashboard/tree/1.5.0) - 2019-08-14
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -66,6 +66,8 @@ export const RESUME_REQUEST_LABEL = 'Upload a resume';
 export const SKILLS_REQUEST_LABEL = 'What skills do you have?';
 export const SKILLS_REQUEST_PLACEHOLDER = 'Javascript, iOS, Android...';
 export const SCHOOL_REQUEST_LABEL = 'What school do you go to?';
+export const TRAVEL_REQUEST_LABEL =
+  'How much will you need to be reimbursed? (Up to $100)';
 
 // Dashboard page
 export const ACCOUNT_NOT_CONFIRMED_MSG = 'You must confirm your account!';

--- a/src/config/degrees.ts
+++ b/src/config/degrees.ts
@@ -1,6 +1,6 @@
 export enum Degrees {
-  UNDERGRADUATE = 'Undergraduate',
   HIGHSCHOOL = 'High School',
+  UNDERGRADUATE = 'Undergraduate',
   GRADUATE = 'Graduate',
   OTHER = 'Other',
 }

--- a/src/config/gradYears.ts
+++ b/src/config/gradYears.ts
@@ -1,2 +1,2 @@
-const GradYearList = [2019, 2020, 2021, 2022, 2023];
+const GradYearList = [2019, 2020, 2021, 2022, 2023, 2024, 2025];
 export const GradYears = GradYearList.map((v) => ({ label: v, value: v }));

--- a/src/features/Application/ManageApplicationContainer.tsx
+++ b/src/features/Application/ManageApplicationContainer.tsx
@@ -513,7 +513,7 @@ class ManageApplicationContainer extends React.Component<
             <FastField
               name={'hacker.application.accommodation.travel'}
               component={FormikElements.FormattedNumber}
-              label="How much will you need to be reimbursed? (Up to $100)"
+              label={CONSTANTS.TRAVEL_REQUEST_LABEL}
               placeholder={0}
               required={true}
               value={fp.values.hacker.application.accommodation.travel}

--- a/src/features/Application/ManageApplicationContainer.tsx
+++ b/src/features/Application/ManageApplicationContainer.tsx
@@ -502,28 +502,17 @@ class ManageApplicationContainer extends React.Component<
           name={'hacker.application.accommodation.barriers'}
         />
         <FastField
-          name={'needsBus'}
-          component={FormikElements.Checkbox}
-          label={CONSTANTS.BUS_REQUEST_LABEL}
-          subtitle={CONSTANTS.BUS_REQUEST_SUBTITLE}
+          name={'hacker.application.accommodation.travel'}
+          component={FormikElements.FormattedNumber}
+          label={CONSTANTS.TRAVEL_REQUEST_LABEL}
+          placeholder={0}
           required={false}
+          value={fp.values.hacker.application.accommodation.travel}
         />
-        {fp.values.needsBus ? (
-          <React.Fragment>
-            <FastField
-              name={'hacker.application.accommodation.travel'}
-              component={FormikElements.FormattedNumber}
-              label={CONSTANTS.TRAVEL_REQUEST_LABEL}
-              placeholder={0}
-              required={true}
-              value={fp.values.hacker.application.accommodation.travel}
-            />
-            <ErrorMessage
-              component={FormikElements.Error}
-              name={'hacker.application.accommodation.travel'}
-            />
-          </React.Fragment>
-        ) : null}
+        <ErrorMessage
+          component={FormikElements.Error}
+          name={'hacker.application.accommodation.travel'}
+        />
         <Flex
           flexDirection={'row'}
           alignItems={'center'}

--- a/src/features/Application/validationSchema.ts
+++ b/src/features/Application/validationSchema.ts
@@ -170,6 +170,12 @@ const getValidationSchema = (isCreate: boolean, pageNumber: number) => {
             }),
             accommodation: object().shape({
               shirtSize: string().required('Required'),
+              impairments: string(),
+              barriers: string(),
+              travel: number()
+                .min(0, 'Must be between 0 and 100')
+                .max(100, 'Must be between 0 and 100')
+                .typeError('Must be a number'),
             }),
           }),
         }),
@@ -233,6 +239,15 @@ const getValidationSchema = (isCreate: boolean, pageNumber: number) => {
                 (value) => !value || value.length < 500
               ),
             }),
+            accommodation: object().shape({
+              shirtSize: string().required('Required'),
+              impairments: string(),
+              barriers: string(),
+              travel: number()
+                .min(0, 'Must be between 0 and 100')
+                .max(100, 'Must be between 0 and 100')
+                .typeError('Must be a number'),
+            }),
             other: object().shape({
               ethnicity: array().required('Required'),
               privacyPolicy: boolean()
@@ -249,9 +264,6 @@ const getValidationSchema = (isCreate: boolean, pageNumber: number) => {
                   'You must accept the McHacks policies',
                   (value) => value
                 ),
-            }),
-            accommodation: object().shape({
-              shirtSize: string().required('Required'),
             }),
           }),
         }),

--- a/src/features/Application/validationSchema.ts
+++ b/src/features/Application/validationSchema.ts
@@ -17,8 +17,8 @@ const getValidationSchema = (isCreate: boolean, pageNumber: number) => {
               fieldOfStudy: string().required('Required'),
               graduationYear: number()
                 .required('Required')
-                .min(2019)
-                .max(2025),
+                .min(2020, 'Graduation year must be 2020 or later')
+                .max(2025, 'Graduation year must be between 2020 and 2025'),
               jobInterest: string().required('Required'),
               URL: object().shape({
                 resume: resumeSchema
@@ -59,8 +59,8 @@ const getValidationSchema = (isCreate: boolean, pageNumber: number) => {
               fieldOfStudy: string().required('Required'),
               graduationYear: number()
                 .required('Required')
-                .min(2019)
-                .max(2025),
+                .min(2020, 'Graduation year must be 2020 or later')
+                .max(2025, 'Graduation year must be between 2020 and 2025'),
               jobInterest: string().required('Required'),
               URL: object().shape({
                 resume: resumeSchema
@@ -121,8 +121,8 @@ const getValidationSchema = (isCreate: boolean, pageNumber: number) => {
               fieldOfStudy: string().required('Required'),
               graduationYear: number()
                 .required('Required')
-                .min(2019)
-                .max(2025),
+                .min(2020, 'Graduation year must be 2020 or later')
+                .max(2025, 'Graduation year must be between 2020 and 2025'),
               jobInterest: string().required('Required'),
               URL: object().shape({
                 resume: resumeSchema
@@ -192,8 +192,8 @@ const getValidationSchema = (isCreate: boolean, pageNumber: number) => {
               fieldOfStudy: string().required('Required'),
               graduationYear: number()
                 .required('Required')
-                .min(2019)
-                .max(2025),
+                .min(2020, 'Graduation year must be 2020 or later')
+                .max(2025, 'Graduation year must be between 2020 and 2025'),
               jobInterest: string().required('Required'),
               URL: object().shape({
                 resume: resumeSchema

--- a/src/features/Application/validationSchema.ts
+++ b/src/features/Application/validationSchema.ts
@@ -17,8 +17,8 @@ const getValidationSchema = (isCreate: boolean, pageNumber: number) => {
               fieldOfStudy: string().required('Required'),
               graduationYear: number()
                 .required('Required')
-                .min(2020, 'Graduation year must be 2020 or later')
-                .max(2025, 'Graduation year must be between 2020 and 2025'),
+                .min(2019, 'Graduation year must be 2019 or later')
+                .max(2025, 'Graduation year must be between 2019 and 2025'),
               jobInterest: string().required('Required'),
               URL: object().shape({
                 resume: resumeSchema
@@ -59,8 +59,8 @@ const getValidationSchema = (isCreate: boolean, pageNumber: number) => {
               fieldOfStudy: string().required('Required'),
               graduationYear: number()
                 .required('Required')
-                .min(2020, 'Graduation year must be 2020 or later')
-                .max(2025, 'Graduation year must be between 2020 and 2025'),
+                .min(2019, 'Graduation year must be 2019 or later')
+                .max(2025, 'Graduation year must be between 2019 and 2025'),
               jobInterest: string().required('Required'),
               URL: object().shape({
                 resume: resumeSchema
@@ -121,8 +121,8 @@ const getValidationSchema = (isCreate: boolean, pageNumber: number) => {
               fieldOfStudy: string().required('Required'),
               graduationYear: number()
                 .required('Required')
-                .min(2020, 'Graduation year must be 2020 or later')
-                .max(2025, 'Graduation year must be between 2020 and 2025'),
+                .min(2019, 'Graduation year must be 2019 or later')
+                .max(2025, 'Graduation year must be between 2019 and 2025'),
               jobInterest: string().required('Required'),
               URL: object().shape({
                 resume: resumeSchema
@@ -192,8 +192,8 @@ const getValidationSchema = (isCreate: boolean, pageNumber: number) => {
               fieldOfStudy: string().required('Required'),
               graduationYear: number()
                 .required('Required')
-                .min(2020, 'Graduation year must be 2020 or later')
-                .max(2025, 'Graduation year must be between 2020 and 2025'),
+                .min(2019, 'Graduation year must be 2019 or later')
+                .max(2025, 'Graduation year must be between 2019 and 2025'),
               jobInterest: string().required('Required'),
               URL: object().shape({
                 resume: resumeSchema


### PR DESCRIPTION
### Tickets:

- HCK-182
- HCK-180
- HCK-183

### List of changes:

- Reorder degrees into chronological order
- Move travel label to `constants.ts`
- Remove `needsBus` from application (I don't think it'll break backend since the field isn't required but we need to remove it there anyways, see HCK-194)
- Add travel field validation
- Update graduation year validation to be **2019-2025**

### Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How did you do this?

### Why are you choosing this approach?

- I removed `needsBus` bc it made `travel` a nested field that needed to be validated
- Update grad years b/c we aren't accepting non-students

### Questions for code reviewers?

How to test:
- Enter # in grad year field that's not 2020-2025 inclusive
- Enter # in travel field that's not 0-100 inclusive

### PR Checklist:

- [x] Merged `develop` branch (before testing)
- [x] Linted my code locally
- [x] Listed change(s) in the Changelog
- [x] Tested all links in project relevant browsers
- [x] Tested all links on different screen sizes
- [x] Referenced all useful info (issues, tasks, etc)
