### PR TITLE
changed submit to update if hacker is editing their application

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change `cancelled` hacker status to `withdrawn`
+- Changed `submit` to `update` based on whether hacker is creating or editing their application
 
 ### Fixed
 

--- a/src/features/Application/ManageApplicationContainer.tsx
+++ b/src/features/Application/ManageApplicationContainer.tsx
@@ -670,7 +670,9 @@ class ManageApplicationContainer extends React.Component<
             isLoading={this.state.submitting}
             disabled={this.state.submitting}
           >
-            Submit
+            {this.state.mode === ManageApplicationModes.CREATE
+              ? 'Submit'
+              : 'Update'}
           </SubmitBtn>
           <div>&nbsp;</div>
         </Flex>


### PR DESCRIPTION
### Tickets:

HCK-207

### List of changes:

Changed `submit` to `update` based on whether hacker is creating or editing their application

### Type of change:

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How did you do this?

Change the text to be displayed based on this.state.mode

### Why are you choosing this approach?

It is THE way to fix it

### Questions for code reviewers?

### PR Checklist:

- [x] Merged `develop` branch (before testing)
- [x] Linted my code locally
- [x] Listed change(s) in the Changelog
- [x] Tested all links in project relevant browsers
- [x] Tested all links on different screen sizes
- [x] Referenced all useful info (issues, tasks, etc)
![Screen Shot 2019-12-21 at 3 52 54 PM](https://user-images.githubusercontent.com/32375237/71313723-9d90b200-240a-11ea-9cb8-689a05a58852.png)
![Screen Shot 2019-12-21 at 3 51 29 PM](https://user-images.githubusercontent.com/32375237/71313724-9d90b200-240a-11ea-926f-81336b08db4e.png)
