### PR TITLE
dropdown list should be above all other elements now

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,11 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Checkmark appearing on dropdown lists due to z-index
 - Job interest dropdown colours
 - Loading page will no longer flash on team page
+- Dropdown list being behind other elements
 
 ### Removed
 
 - Remove `needsBus` value in ManageApplicationContainer
-- Remove  "Loading..." string
+- Remove "Loading..." string
 
 ## [2.0.0](https://github.com/hackmcgill/dashboard/tree/2.0.0) - 2019-12-17
 

--- a/src/shared/Form/FormikElements/Checkbox.tsx
+++ b/src/shared/Form/FormikElements/Checkbox.tsx
@@ -27,6 +27,7 @@ const CheckboxContainer = styled.div`
   input:checked {
     background-color: #f2463a;
     border-color: #f2463a;
+    z-index: -1;
   }
 
   /* Checkmark icon based on StackOverflow icon by dayuloli
@@ -40,7 +41,6 @@ const CheckboxContainer = styled.div`
     position: relative;
     left: 25px;
     top: 3px;
-    z-index: 1;
     display: inline-block;
     cursor: pointer;
   }

--- a/src/shared/Form/StyledCreatableSelect.tsx
+++ b/src/shared/Form/StyledCreatableSelect.tsx
@@ -4,7 +4,6 @@ import styled from '../Styles/styled-components';
 
 export const StyledCreatableSelect = styled(CreatableSelect)`
   font-family: ${(props) => props.theme.fonts.body};
-  z-index: 2;
 
   .react-select__control {
     ${inputStyles}

--- a/src/shared/Form/StyledSelect.tsx
+++ b/src/shared/Form/StyledSelect.tsx
@@ -4,7 +4,6 @@ import styled from '../Styles/styled-components';
 
 export const StyledSelect = styled(Select)`
   font-family: ${(props) => props.theme.fonts.body};
-  z-index: 2;
 
   .react-select__control {
     ${inputStyles}


### PR DESCRIPTION
### Tickets:

- HCK-225

### List of changes:

- Dropdown list should be above other elements now

### Type of change:

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How did you do this?

Removed previous z-Index changes, and just changed the checkbox background to -1, as this was related to another ticket I fixed.

### Why are you choosing this approach?

Doesn't cause issues with other elements

### Questions for code reviewers?

### PR Checklist:

- [x] Merged `develop` branch (before testing)
- [x] Linted my code locally
- [x] Listed change(s) in the Changelog
- [x] Tested all links in project relevant browsers
- [x] Tested all links on different screen sizes
- [x] Referenced all useful info (issues, tasks, etc)
![Screen Shot 2019-12-23 at 5 41 56 PM](https://user-images.githubusercontent.com/32375237/71383706-8b01ae80-25ab-11ea-965e-0da5dfd32a4c.png)
