### PR TITLE
Feature/228 url validation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dropdown list being behind other elements
 - School dropdown list uses Hind font now
 - Privacy policy error message displayed properly now
+- URL validation allows empty strings
 
 ### Removed
 

--- a/src/features/Application/validationSchema.ts
+++ b/src/features/Application/validationSchema.ts
@@ -24,16 +24,22 @@ const getValidationSchema = (isCreate: boolean, pageNumber: number) => {
                 resume: string(),
                 github: string()
                   .url('Must be a valid URL')
-                  .matches(/github.com\/\w+/, 'Must be a valid Github URL'),
+                  .matches(/github.com\/w+/, {
+                    message: 'Must be a valid Github URL',
+                    excludeEmptyString: true,
+                  }),
                 dribbble: string()
                   .url('Must be a valid URL')
-                  .matches(/dribbble.com\/\w+/, 'Must be a valid Dribbble URL'),
+                  .matches(/dribbble.com\/\w+/, {
+                    message: 'Must be a valid Dribbble URL',
+                    excludeEmptyString: true,
+                  }),
                 linkedIn: string()
                   .url('Must be a valid URL')
-                  .matches(
-                    /linkedin.com\/in\/\w+/,
-                    'Must be a valid LinkedIn URL'
-                  ),
+                  .matches(/linkedin.com\/in\/\w+/, {
+                    message: 'Must be a valid LinkedIn URL',
+                    excludeEmptyString: true,
+                  }),
                 personal: string().url('Must be a valid URL'),
                 other: string().url('Must be a valid URL'),
               }),
@@ -73,16 +79,22 @@ const getValidationSchema = (isCreate: boolean, pageNumber: number) => {
                 resume: string(),
                 github: string()
                   .url('Must be a valid URL')
-                  .matches(/github.com\/\w+/, 'Must be a valid Github URL'),
+                  .matches(/github.com\/w+/, {
+                    message: 'Must be a valid Github URL',
+                    excludeEmptyString: true,
+                  }),
                 dribbble: string()
                   .url('Must be a valid URL')
-                  .matches(/dribbble.com\/\w+/, 'Must be a valid Dribbble URL'),
+                  .matches(/dribbble.com\/\w+/, {
+                    message: 'Must be a valid Dribbble URL',
+                    excludeEmptyString: true,
+                  }),
                 linkedIn: string()
                   .url('Must be a valid URL')
-                  .matches(
-                    /linkedin.com\/in\/\w+/,
-                    'Must be a valid LinkedIn URL'
-                  ),
+                  .matches(/linkedin.com\/in\/\w+/, {
+                    message: 'Must be a valid LinkedIn URL',
+                    excludeEmptyString: true,
+                  }),
                 personal: string().url('Must be a valid URL'),
                 other: string().url('Must be a valid URL'),
               }),
@@ -142,16 +154,22 @@ const getValidationSchema = (isCreate: boolean, pageNumber: number) => {
                 resume: string(),
                 github: string()
                   .url('Must be a valid URL')
-                  .matches(/github.com\/\w+/, 'Must be a valid Github URL'),
+                  .matches(/github.com\/w+/, {
+                    message: 'Must be a valid Github URL',
+                    excludeEmptyString: true,
+                  }),
                 dribbble: string()
                   .url('Must be a valid URL')
-                  .matches(/dribbble.com\/\w+/, 'Must be a valid Dribbble URL'),
+                  .matches(/dribbble.com\/\w+/, {
+                    message: 'Must be a valid Dribbble URL',
+                    excludeEmptyString: true,
+                  }),
                 linkedIn: string()
                   .url('Must be a valid URL')
-                  .matches(
-                    /linkedin.com\/in\/\w+/,
-                    'Must be a valid LinkedIn URL'
-                  ),
+                  .matches(/linkedin.com\/in\/\w+/, {
+                    message: 'Must be a valid LinkedIn URL',
+                    excludeEmptyString: true,
+                  }),
                 personal: string().url('Must be a valid URL'),
                 other: string().url('Must be a valid URL'),
               }),
@@ -221,16 +239,22 @@ const getValidationSchema = (isCreate: boolean, pageNumber: number) => {
                 resume: string(),
                 github: string()
                   .url('Must be a valid URL')
-                  .matches(/github.com\/\w+/, 'Must be a valid Github URL'),
+                  .matches(/github.com\/w+/, {
+                    message: 'Must be a valid Github URL',
+                    excludeEmptyString: true,
+                  }),
                 dribbble: string()
                   .url('Must be a valid URL')
-                  .matches(/dribbble.com\/\w+/, 'Must be a valid Dribbble URL'),
+                  .matches(/dribbble.com\/\w+/, {
+                    message: 'Must be a valid Dribbble URL',
+                    excludeEmptyString: true,
+                  }),
                 linkedIn: string()
                   .url('Must be a valid URL')
-                  .matches(
-                    /linkedin.com\/in\/\w+/,
-                    'Must be a valid LinkedIn URL'
-                  ),
+                  .matches(/linkedin.com\/in\/\w+/, {
+                    message: 'Must be a valid LinkedIn URL',
+                    excludeEmptyString: true,
+                  }),
                 personal: string().url('Must be a valid URL'),
                 other: string().url('Must be a valid URL'),
               }),


### PR DESCRIPTION
### Tickets:

- HCK-228

### List of changes:

- Allowed URLs to be empty for dribbble, github, linkedin.

### Type of change:

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How did you do this?

Add option to allow empty strings

### How to test:

You can go to next field now without inputs?

### Questions:

### PR Checklist:

- [x] Merged `develop` branch (before testing)
- [x] Linted my code locally
- [x] Listed change(s) in the Changelog
- [x] Tested all links in project relevant browsers
- [x] Tested all links on different screen sizes
- [x] Referenced all useful info (issues, tasks, etc)

### Screenshots:
![41a903bab9fe719ebf25dbcacc823120](https://user-images.githubusercontent.com/32375237/71488744-2e430580-27f0-11ea-9e54-ec64eae960a1.gif)
