### PR TITLE
Fixed URL validation for github

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Fixed
+
+- URL validation for github
+
 ## [2.0.2](https://github.com/hackmcgill/dashboard/tree/2.0.2) - 2019-12-26
 
 ### Fixed

--- a/src/features/Application/validationSchema.ts
+++ b/src/features/Application/validationSchema.ts
@@ -24,7 +24,7 @@ const getValidationSchema = (isCreate: boolean, pageNumber: number) => {
                 resume: string(),
                 github: string()
                   .url('Must be a valid URL')
-                  .matches(/github.com\/w+/, {
+                  .matches(/github.com\/\w+/, {
                     message: 'Must be a valid Github URL',
                     excludeEmptyString: true,
                   }),
@@ -79,7 +79,7 @@ const getValidationSchema = (isCreate: boolean, pageNumber: number) => {
                 resume: string(),
                 github: string()
                   .url('Must be a valid URL')
-                  .matches(/github.com\/w+/, {
+                  .matches(/github.com\/\w+/, {
                     message: 'Must be a valid Github URL',
                     excludeEmptyString: true,
                   }),
@@ -154,7 +154,7 @@ const getValidationSchema = (isCreate: boolean, pageNumber: number) => {
                 resume: string(),
                 github: string()
                   .url('Must be a valid URL')
-                  .matches(/github.com\/w+/, {
+                  .matches(/github.com\/\w+/, {
                     message: 'Must be a valid Github URL',
                     excludeEmptyString: true,
                   }),
@@ -239,7 +239,7 @@ const getValidationSchema = (isCreate: boolean, pageNumber: number) => {
                 resume: string(),
                 github: string()
                   .url('Must be a valid URL')
-                  .matches(/github.com\/w+/, {
+                  .matches(/github.com\/\w+/, {
                     message: 'Must be a valid Github URL',
                     excludeEmptyString: true,
                   }),


### PR DESCRIPTION
### Tickets:

- HCK-230

### List of changes:

- Github field allows any user name, not just starting with w's

### Type of change:

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How did you do this?

Add the escape character

### How to test:

### Questions:

### PR Checklist:

- [x] Merged `develop` branch (before testing)
- [x] Linted my code locally
- [x] Listed change(s) in the Changelog
- [x] Tested all links in project relevant browsers
- [x] Tested all links on different screen sizes
- [x] Referenced all useful info (issues, tasks, etc)

### Screenshots:
![b5c649f7fa1d8ed7c0dca600096d14a9](https://user-images.githubusercontent.com/32375237/71549115-13a29500-2986-11ea-9c8b-be7f8f7bb509.gif)
