### PR TITLE
Add status page text constants

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add status page text constants
+
+### Changed
+
+- Switch status page text to use constants
+
 ## [2.0.3](https://github.com/hackmcgill/dashboard/tree/2.0.3) - 2019-12-28
 
 ### Fixed

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -46,6 +46,23 @@ export const BIRTH_DATE_LABEL = 'Birth Date';
 export const FIRST_NAME_LABEL = 'First Name';
 export const LAST_NAME_LABEL = 'Last Name';
 
+// Status management
+export const NONE_STATUS_TEXT =
+  'You’re all set! Ready to start your application?';
+export const APPLIED_STATUS_TEXT =
+  'Your application has been submitted. Decisions will be sent out in January so stay tuned!';
+export const ACCEPTED_STATUS_TEXT =
+  "Congratulations! We're excited to offer you a spot at McHacks! Please RSVP by January 22, 2020 to secure your spot and we'll see you there.";
+export const DECLINED_STATUS_TEXT =
+  "Thank you so much for your interest in McHacks. Unfortunately, we don't have enough space to offer you a spot this year. That being said, please keep in touch and we'd love to see you apply again next year! In the meantime, we hope you continue to create and build awesome things!";
+export const WAITLISTED_STATUS_TEXT =
+  "Thank you so much for your interest in McHacks. We receive many applications each year and wish we had the capacity to offer a spot to everyone. At the moment, we aren't able to offer you a spot and have placed you on the waitlist. Keep an eye out on the dashboard to see if your status changes and a spot opens up!";
+export const CONFIRMED_STATUS_TEXT =
+  'Your attendance has been confirmed! More information on McHacks will be sent to your inbox as we get closer to the event.';
+export const WITHDRAWN_STATUS_TEXT =
+  "We're sorry to hear you're unable to make it to McHacks this year. Please keep in touch and hopefully we'll see you at the next one";
+export const CHECKED_IN_STATUS_TEXT = 'You’re checked-in and ready to go!';
+
 // Application management
 export const BARRIERS_LABEL = 'Would you require any accommodations?';
 export const BUS_REQUEST_LABEL = 'Will you require a seat on a bus?';

--- a/src/features/Status/StatusPage.tsx
+++ b/src/features/Status/StatusPage.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import Helmet from 'react-helmet';
 
 import { Box, Flex } from '@rebass/grid';
+import * as CONSTANTS from '../../config/constants';
 import {
   BackgroundImage,
   Button,
@@ -11,7 +12,6 @@ import {
 } from '../../shared/Elements';
 // import Sidebar from '../Sidebar/Sidebar';
 
-import Background from '../../assets/images/statuspage-background.svg';
 import {
   FrontendRoute,
   HACKATHON_NAME,
@@ -20,6 +20,8 @@ import {
 } from '../../config';
 import theme from '../../shared/Styles/theme';
 import ConfirmationEmailSentComponent from '../Account/ConfirmationEmailSentComponent';
+
+import Background from '../../assets/images/statuspage-background.svg';
 
 export interface IStatusPageProps {
   account?: IAccount;
@@ -56,8 +58,7 @@ class StatusPage extends React.Component<IStatusPageProps, {}> {
                     textAlign={'center'}
                     marginBottom={'3rem'}
                   >
-                    Your application has been submitted. Decisions will be sent
-                    out in January so stay tuned!
+                    {CONSTANTS.APPLIED_STATUS_TEXT}
                   </Paragraph>
                   <LinkDuo to={FrontendRoute.EDIT_APPLICATION_PAGE}>
                     <Button type="button">View/Edit Application</Button>
@@ -74,7 +75,7 @@ class StatusPage extends React.Component<IStatusPageProps, {}> {
                     textAlign={'center'}
                     marginBottom={'3rem'}
                   >
-                    You’re all set! Ready to start your application?
+                    {CONSTANTS.NONE_STATUS_TEXT}
                   </Paragraph>
                   <LinkDuo to={FrontendRoute.CREATE_APPLICATION_PAGE}>
                     <Button type="button">Apply</Button>


### PR DESCRIPTION
### Tickets:

- HCK-92

### List of changes:

- Add string constants for each hacker status text
- Change text in `StatusPage.tsx` to use the new constants

### Type of change:

- [x] New feature (non-breaking change which adds functionality)

### How did you do this?

### How to test:

- Change hacker status to `None` and `Applied` to see if the appropriate text shows up
- Other statuses haven't been updated for the status page yet (that'll be HCK-211)

### Questions:

- Read over text for spelling errors + that it's fine for UX

### PR Checklist:

- [x] Merged `develop` branch (before testing)
- [x] Linted my code locally
- [x] Listed change(s) in the Changelog
- [x] Tested all links in project relevant browsers
- [x] Tested all links on different screen sizes
- [x] Referenced all useful info (issues, tasks, etc)

### Screenshots:
