### PR TITLE
Fixed confirm email component flashing when navigating to homepage

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Confirm email component flashing when navigating to home page
+
 ## [2.0.3](https://github.com/hackmcgill/dashboard/tree/2.0.3) - 2019-12-28
 
 ### Fixed

--- a/src/features/Dashboard/HackerDashboard.tsx
+++ b/src/features/Dashboard/HackerDashboard.tsx
@@ -10,6 +10,7 @@ export interface IDashboardState {
   account: IAccount;
   status: HackerStatus;
   confirmed: boolean;
+  loaded: boolean;
 }
 
 class HackerDashboardContainer extends React.Component<{}, IDashboardState> {
@@ -19,6 +20,7 @@ class HackerDashboardContainer extends React.Component<{}, IDashboardState> {
       account: Object(),
       status: HackerStatus.HACKER_STATUS_NONE,
       confirmed: false,
+      loaded: false,
     };
   }
   public async componentDidMount() {
@@ -50,9 +52,11 @@ class HackerDashboardContainer extends React.Component<{}, IDashboardState> {
     } catch (e) {
       this.setState({ confirmed });
     }
+    this.setState({ loaded: true });
   }
   public render() {
-    return <StatusPage {...this.state} />;
+    // this will prevent loading the default confirm email component page if the componentDidMount has not finished it's async methods
+    return this.state.loaded ? <StatusPage {...this.state} /> : null;
   }
 }
 

--- a/src/features/Status/StatusPage.tsx
+++ b/src/features/Status/StatusPage.tsx
@@ -9,7 +9,6 @@ import {
   LinkDuo,
   Paragraph,
 } from '../../shared/Elements';
-// import Sidebar from '../Sidebar/Sidebar';
 
 import Background from '../../assets/images/statuspage-background.svg';
 import {


### PR DESCRIPTION
### Tickets:

- HCK-200

### List of changes:

- Confirm email component does not flash when navigating home now

### Type of change:

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How did you do this?

- Make component render if async methods have finished.

### How to test:

- Refresh page and see if it flashes

### Questions:

### PR Checklist:

- [x] Merged `develop` branch (before testing)
- [x] Linted my code locally
- [x] Listed change(s) in the Changelog
- [x] Tested all links in project relevant browsers
- [x] Tested all links on different screen sizes
- [x] Referenced all useful info (issues, tasks, etc)

### Screenshots:
Can't really make a gif/screenshot showing it working properly:/