### PR TITLE
Fix missing space in create/edit account site title

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Switch status page text to use constants
 
+### Fixed
+
+- Fix missing space in Create/Edit Account site title
+
 ## [2.0.3](https://github.com/hackmcgill/dashboard/tree/2.0.3) - 2019-12-28
 
 ### Fixed

--- a/src/features/Account/ManageAccountContainer.tsx
+++ b/src/features/Account/ManageAccountContainer.tsx
@@ -187,7 +187,7 @@ class ManageAccountContainer extends React.Component<
         </>
         <Helmet>
           <title>
-            {mode === ManageAccountModes.CREATE ? 'Create ' : 'Edit '} Account |
+            {mode === ManageAccountModes.CREATE ? 'Create ' : 'Edit '} Account |{' '}
             {CONSTANTS.HACKATHON_NAME}
           </title>
         </Helmet>


### PR DESCRIPTION
### Tickets:

- HCK-231

### List of changes:

- Fix missing space in create/edit account site title

### Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)

### How did you do this?

### How to test:

Go to `/account/edit` or `/account/create` and check site title has space

### Questions:

### PR Checklist:

- [x] Merged `develop` branch (before testing)
- [x] Linted my code locally
- [x] Listed change(s) in the Changelog
- [x] Tested all links in project relevant browsers
- [x] Tested all links on different screen sizes
- [x] Referenced all useful info (issues, tasks, etc)

### Screenshots:

![image](https://user-images.githubusercontent.com/23108291/71636921-d3514a00-2c05-11ea-85ac-cbc41c3185e9.png)