### PR TITLE
added route for well known password change

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -127,6 +127,11 @@ class App extends React.Component {
             />
             <Route
               exact={true}
+              path={FrontendRoute.WELL_KNOWN_PASSWORD_CHANGE}
+              component={withNavbar(ForgotPasswordContainer)}
+            />
+            <Route
+              exact={true}
               path={FrontendRoute.CREATE_APPLICATION_PAGE}
               component={withNavbar(
                 withAuthRedirect(

--- a/src/config/frontendRoutes.ts
+++ b/src/config/frontendRoutes.ts
@@ -10,6 +10,7 @@ export enum FrontendRoute {
   EDIT_ACCOUNT_PAGE = '/account/edit',
   EDIT_APPLICATION_PAGE = '/application/edit',
   FORGOT_PASSWORD_PAGE = '/password/forgot',
+  WELL_KNOWN_PASSWORD_CHANGE = '/.well-known/change-password',
   HOME_PAGE = '/',
   LOGIN_PAGE = '/login',
   RESET_PASSWORD_PAGE = '/password/reset',


### PR DESCRIPTION
### Tickets:
fixes #652 
- HCK-

### List of changes:

-added route from /.well-known/change-password to 'forgot password' page

### Type of change:

Please delete options that aren't relevant.

### How did you do this?

### How to test:
-I think it only works on safari and not chrome because I can't change password from my chrome browser. Probably need to test using a mac and safari.

### Questions:

### PR Checklist:

- [ ] Merged `develop` branch (before testing)
- [ ] Linted my code locally
- [ ] Listed change(s) in the Changelog
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links on different screen sizes
- [ ] Referenced all useful info (issues, tasks, etc)

### Screenshots:
![image](https://user-images.githubusercontent.com/45922265/84086446-ec7cd480-a9b5-11ea-8bcf-e955e3b16b83.png)
