### PR TITLE
fix: add fallback font face during font render

### DIFF
--- a/src/shared/Styles/GlobalStyles.tsx
+++ b/src/shared/Styles/GlobalStyles.tsx
@@ -8,6 +8,7 @@ export const GlobalStyles = createGlobalStyle`
     font-style: normal;
     font-weight: regular;
     src: url('/fonts/lineto-brown-regular.ttf');
+    font-display: swap;
   }
 
   @font-face {
@@ -15,6 +16,7 @@ export const GlobalStyles = createGlobalStyle`
     font-style: normal;
     font-weight: bold;
     src: url("/fonts/lineto-brown-bold.ttf");
+    font-display: swap;
   }
 
   body {


### PR DESCRIPTION
### Tickets:

- #825 

### List of changes:

- added fallback font face in the global styles page

### Type of change:

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How did you do this?
- googled the issue to find similar examples

### How to test:

### Questions:

### PR Checklist:

- [x] Merged `develop` branch (before testing)
- [x] Linted my code locally
- [x] Listed change(s) in the Changelog
- [x] Tested all links in project relevant browsers
- [x] Tested all links on different screen sizes
- [x] Referenced all useful info (issues, tasks, etc)

### Screenshots:
