### PR TITLE
feat: Create client-side API endpoint for settings

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -6,4 +6,5 @@ export * from './endpoint';
 export * from './hacker';
 export * from './travel';
 export * from './search';
+export * from './settings';
 export * from './sponsor';

--- a/src/api/settings.ts
+++ b/src/api/settings.ts
@@ -1,0 +1,26 @@
+import { AxiosPromise } from 'axios';
+import { APIResponse } from '.';
+import { APIRoute, ISetting } from '../config';
+import API from './api';
+
+class SettingsAPI {
+  constructor() {
+    API.createEntity(APIRoute.SETTINGS);
+  }
+  /**
+   * Update the settings.
+   * @param setting The settings that you want to update
+   */
+  public update(setting: ISetting): AxiosPromise {
+    return API.getEndpoint(APIRoute.SETTINGS).create(setting);
+  }
+  /**
+   * Get the current settings
+   */
+  public get(): AxiosPromise<APIResponse<ISetting>> {
+    return API.getEndpoint(APIRoute.SETTINGS).getAll();
+  }
+}
+
+export const Settings = new SettingsAPI();
+export default Settings;

--- a/src/config/APIRoute.ts
+++ b/src/config/APIRoute.ts
@@ -27,6 +27,8 @@ export enum APIRoute {
   TRAVEL_SELF = 'travel/self',
   // Search routes
   SEARCH = 'search',
+  // Settings routes
+  SETTINGS = 'settings',
   // Sponsor routes
   SPONSOR = 'sponsor',
   SPONSOR_SELF = 'sponsor/self',

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -16,6 +16,7 @@ export * from './resumeResponse';
 export * from './schools';
 export * from './searchOptions';
 export * from './searchParameter';
+export * from './settings';
 export * from './shirtSizes';
 export * from './skills';
 export * from './statsResponse';

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -1,0 +1,5 @@
+export interface ISetting {
+  openTime: string;
+  closeTime: string;
+  confirmTime: string;
+}


### PR DESCRIPTION
### Tickets:

fixes: #852

### List of changes:

- create ISettings schema
- add API endpoint for schemas

### Type of change:

Please delete options that aren't relevant.

- [x] New feature (non-breaking change which adds functionality)

### How to test:

Nothing uses this endpoint right now, so there is no way to test this atm.

### Questions:

### PR Checklist:

- [x] Merged `develop` branch (before testing)
- [x] Linted my code locally
- [ ] Listed change(s) in the Changelog
- [x] Referenced all useful info (issues, tasks, etc)

### Screenshots:

no need.