### PR TITLE
feat: very slight gradient background via withBackground hoc

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    
+
   <link rel="apple-touch-icon" sizes="57x57" href="%PUBLIC_URL%/favicon/apple-touch-icon-57x57.png" />
   <link rel="apple-touch-icon" sizes="114x114" href="%PUBLIC_URL%/favicon/apple-touch-icon-114x114.png" />
   <link rel="apple-touch-icon" sizes="72x72" href="%PUBLIC_URL%/favicon/apple-touch-icon-72x72.png" />
@@ -47,6 +47,17 @@
   <meta name="theme-color" content="#F2463A">
   <meta name="msapplication-navbutton-color" content="#F2463A">
   <meta name="apple-mobile-web-app-status-bar-style" content="#F2463A">
+
+  <style>
+    #root,
+    #root>div {
+      width: 100%;
+      height: 100%;
+      min-height: 100vh;
+      margin: 0;
+      padding: 0;
+    }
+  </style>
 
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-120508272-2"></script>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import {
 import * as CONSTANTS from './config/constants';
 
 import withAuthRedirect from './shared/HOC/withAuthRedirect';
+import withBackground from './shared/HOC/withBackground';
 import withHackerRedirect from './shared/HOC/withHackerRedirect';
 import withNavbar from './shared/HOC/withNavbar';
 import withSponsorRedirect from './shared/HOC/withSponsorRedirect';
@@ -53,7 +54,7 @@ class App extends React.Component {
   public render() {
     return (
       <BrowserRouter>
-        <div>
+        <>
           <Helmet>
             <title>{CONSTANTS.HACKATHON_NAME}</title>
             <meta property="og:title" content={CONSTANTS.HACKATHON_NAME} />
@@ -206,12 +207,12 @@ class App extends React.Component {
             <Route
               exact={true}
               path={FrontendRoute.LOGIN_PAGE}
-              component={withNavbar(
+              component={withBackground(withNavbar(
                 withAuthRedirect(LoginPage, {
                   requiredAuthState: false,
                 }),
                 { activePage: 'login' }
-              )}
+              ))}
             />
             <Route
               exact={true}
@@ -348,7 +349,7 @@ class App extends React.Component {
             />
             <Route path="*" component={withNavbar(ErrorPage)} />
           </Switch>
-        </div>
+        </>
       </BrowserRouter>
     );
   }

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -156,16 +156,16 @@ const LoginPage: React.FC = () => {
             />
           </LeftContainer>
         ) : (
-          <div>
-            {renderForm()}
-            <BackgroundImage
-              src={Coders}
-              top={'60px'}
-              right={'0px'}
-              imgHeight={'100%'}
-            />
-          </div>
-        )
+            <>
+              {renderForm()}
+              <BackgroundImage
+                src={Coders}
+                top={'60px'}
+                right={'0px'}
+                imgHeight={'100%'}
+              />
+            </>
+          )
       }
     </MediaQuery>
   );

--- a/src/shared/HOC/withBackground.tsx
+++ b/src/shared/HOC/withBackground.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import theme from '../../shared/Styles/theme';
+
+const withBackground = <P extends {}>(
+    Component: React.ComponentType<P>
+): React.FC => {
+    return (props: P) => {
+        return (
+            <div style={styles.background}>
+                <Component key={1} {...props} />
+            </div>
+        );
+    }
+};
+
+const styles = {
+    background: {
+        width: '100%',
+        height: '100%',
+        minHeight: '100vh',
+        background: `linear-gradient(to bottom, ${theme.colors.white}, ${theme.colors.black5} 100%)`,
+        zIndex: -1001
+    }
+}
+
+export default withBackground;


### PR DESCRIPTION
### Tickets:

- HCK- #876 

### List of changes:

- Very slight (#fff to #f4f4f4) gradient background for pages, addable by wrapping a page in `withBackground()`

### Type of change:

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How did you do this?

### How to test:

### Questions:

### PR Checklist:

- [x] Merged `develop` branch (before testing)
- [x] Linted my code locally
- [ ] Listed change(s) in the Changelog
- [x] Tested all links in project relevant browsers
- [x] Tested all links on different screen sizes
- [x] Referenced all useful info (issues, tasks, etc)

### Screenshots