### PR TITLE
Fix: 913 double resume picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "react-autosuggest": "^9.4.3",
     "react-burger-menu": "^2.6.13",
     "react-dom": "^16.13.1",
-    "react-dropzone": "^8.0.4",
+    "react-dropzone": "^11.2.4",
     "react-helmet": "^5.2.0",
     "react-modal": "^3.8.1",
     "react-number-format": "^4.0.6",

--- a/src/features/Application/ManageApplicationForm.tsx
+++ b/src/features/Application/ManageApplicationForm.tsx
@@ -751,7 +751,7 @@ const ManageApplicationForm: React.FC<IManageApplicationProps> = (props) => {
             </div>
           </div>
         </div>
-        
+
         <div className="buttons">
           <Button type="reset" isLoading={false} disabled={isSubmitting} variant={ButtonVariant.Secondary} isOutlined={true} style={{ marginRight: '24px' }}>
             Back
@@ -1027,7 +1027,12 @@ const ManageApplicationForm: React.FC<IManageApplicationProps> = (props) => {
 
     setPageNumber(values.pageNumber - 1);
     setHackerDetails(app);
-    setResume(resume || values.resume);
+
+    if (resume !== values.resume && values.resume) {
+      setResume(values.resume);
+    } else {
+      setResume(resume || values.resume);
+    }
 
     // Reset scroll to top of page
     window.scrollTo(0, 0);
@@ -1052,7 +1057,12 @@ const ManageApplicationForm: React.FC<IManageApplicationProps> = (props) => {
     }
     setPageNumber(values.pageNumber + 1);
     setHackerDetails(app);
-    setResume(resume || values.resume);
+
+    if (resume !== values.resume && values.resume) {
+      setResume(values.resume);
+    } else {
+      setResume(resume || values.resume);
+    }
 
     // Reset scroll to top of page
     window.scrollTo(0, 0);

--- a/src/features/Application/ResumeComponent.tsx
+++ b/src/features/Application/ResumeComponent.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex } from '@rebass/grid';
+import { Box } from '@rebass/grid';
 import { FieldProps } from 'formik';
 import * as React from 'react';
 import ViewPDFComponent from '../../shared/Elements/ViewPDF';
@@ -15,15 +15,15 @@ export interface IResumeProps {
 const ResumeComponent: React.FC<IResumeProps & FieldProps> = (props) => {
   const viewResume = <ViewPDFComponent {...props} />;
   return (
-    <Flex mb={'20px'}>
+    <div style={{ marginBottom: '20px' }}>
       <Box>{props.mode === ManageApplicationModes.EDIT && viewResume}</Box>
       <Box ml={props.mode === ManageApplicationModes.EDIT ? '10px' : ''}>
         <Label>
           <LabelText label={props.label} required={props.required} />
-          <FileUpload {...props} />
         </Label>
+        <FileUpload {...props} />
       </Box>
-    </Flex>
+    </div>
   );
 };
 export { ResumeComponent };

--- a/src/shared/Form/FileUpload.tsx
+++ b/src/shared/Form/FileUpload.tsx
@@ -13,7 +13,9 @@ interface IUploadComponent {
 export const FileUpload: React.StatelessComponent<
   IUploadComponent & FieldProps
 > = (props) => {
-  const [fileName, setFileName] = useState('');
+  const [fileName, setFileName] = useState(
+    props.field.value != null ? props.field.value.name : ''
+  );
   const onUpload = (acceptedFiles: File[]) => {
     if (acceptedFiles.length > 0) {
       setFileName(acceptedFiles[0].name);


### PR DESCRIPTION
### Tickets:

- HCK-#913

### List of changes:

- Updated react-dropzone
- Fixed double picker problem
- Improve "View Resume" button visuals
- Maintain filename on resume component through page navigation
- Fixed resume set logic on page navigation

### Type of change:

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How did you do this?

### How to test:

### Questions:

### PR Checklist:

- [x] Merged `develop` branch (before testing)
- [x] Linted my code locally
- [ ] Listed change(s) in the Changelog
- [x] Tested all links in project relevant browsers
- [x] Tested all links on different screen sizes
- [x] Referenced all useful info (issues, tasks, etc)

### Screenshots:

fixes #913 