### PR TITLE
feat: clean up staff/sponsor and 404 page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -120,12 +120,14 @@ class App extends React.Component {
             <Route
               exact={true}
               path={FrontendRoute.CONFIRM_ACCOUNT_PAGE}
-              component={withNavbar(
-                withAuthRedirect(ConfirmAccountPage, {
-                  requiredAuthState: true,
-                  redirAfterLogin: true,
-                }),
-                { activePage: 'home' }
+              component={withBackground(
+                withNavbar(
+                  withAuthRedirect(ConfirmAccountPage, {
+                    requiredAuthState: true,
+                    redirAfterLogin: true,
+                  }),
+                  { activePage: 'home' }
+                )
               )}
             />
             <Route
@@ -263,51 +265,60 @@ class App extends React.Component {
             <Route
               exact={true}
               path={FrontendRoute.SETTINGS_PAGE}
-              component={withNavbar(
-                withAuthRedirect(SettingsPage, {
-                  requiredAuthState: true,
-                  redirAfterLogin: true,
-                  AuthVerification: (user: IAccount) =>
-                    user.confirmed && user.accountType === UserType.STAFF,
-                }),
-                { activePage: 'settings' }
+              component={withBackground(
+                withNavbar(
+                  withAuthRedirect(SettingsPage, {
+                    requiredAuthState: true,
+                    redirAfterLogin: true,
+                    AuthVerification: (user: IAccount) =>
+                      user.confirmed && user.accountType === UserType.STAFF,
+                  }),
+                  { activePage: 'settings' }
+                )
               )}
             />
             <Route
               exact={true}
               path={FrontendRoute.INVITE_PAGE}
-              component={withNavbar(
-                withAuthRedirect(InvitePage, {
-                  requiredAuthState: true,
-                  redirAfterLogin: true,
-                  AuthVerification: (user: IAccount) =>
-                    user.confirmed && user.accountType === UserType.STAFF,
-                }),
-                { activePage: 'invite' }
+              component={withBackground(
+                withNavbar(
+                  withAuthRedirect(InvitePage, {
+                    requiredAuthState: true,
+                    redirAfterLogin: true,
+                    AuthVerification: (user: IAccount) =>
+                      user.confirmed && user.accountType === UserType.STAFF,
+                  }),
+                  { activePage: 'invite' }
+                )
               )}
             />
             <Route
               exact={true}
               path={FrontendRoute.SPONSOR_SEARCH_PAGE}
-              component={withNavbar(
-                withAuthRedirect(SponsorSearchPage, {
-                  requiredAuthState: true,
-                  redirAfterLogin: true,
-                  AuthVerification: (user: IAccount) =>
-                    user.confirmed && isSponsor(user),
-                }),
-                { activePage: 'search' }
-              )}
+              component={
+                withBackground(
+                  withNavbar(
+                    withAuthRedirect(SponsorSearchPage, {
+                      requiredAuthState: true,
+                      redirAfterLogin: true,
+                      AuthVerification: (user: IAccount) =>
+                        user.confirmed && isSponsor(user),
+                    }),
+                    { activePage: 'search' }
+                  )
+                )}
             />
             <Route
               exact={true}
               path={FrontendRoute.VIEW_HACKER_PAGE}
-              component={withNavbar(
-                withAuthRedirect(SingleHackerPage, {
-                  requiredAuthState: true,
-                  redirAfterLogin: true,
-                  AuthVerification: userCanAccessHackerPage,
-                })
+              component={withBackground(
+                withNavbar(
+                  withAuthRedirect(SingleHackerPage, {
+                    requiredAuthState: true,
+                    redirAfterLogin: true,
+                    AuthVerification: userCanAccessHackerPage,
+                  })
+                )
               )}
             />
             <Route
@@ -326,56 +337,62 @@ class App extends React.Component {
             <Route
               exact={true}
               path={FrontendRoute.CREATE_SPONSOR_PAGE}
-              component={withNavbar(
-                withAuthRedirect(
-                  withSponsorRedirect(CreateSponsorPage, {
-                    requiredAuthState: false,
-                  }),
-                  {
-                    redirAfterLogin: true,
-                    AuthVerification: (user: IAccount) =>
-                      user.confirmed && isSponsor(user),
-                  }
-                ),
-                { activePage: 'sponsor' }
+              component={withBackground(
+                withNavbar(
+                  withAuthRedirect(
+                    withSponsorRedirect(CreateSponsorPage, {
+                      requiredAuthState: false,
+                    }),
+                    {
+                      redirAfterLogin: true,
+                      AuthVerification: (user: IAccount) =>
+                        user.confirmed && isSponsor(user),
+                    }
+                  ),
+                  { activePage: 'sponsor' }
+                )
               )}
             />
             <Route
               exact={true}
               path={FrontendRoute.PASS_HACKER_PAGE}
-              component={withNavbar(
-                withAuthRedirect(
-                  withHackerRedirect(HackPassPage, {
-                    requiredAuthState: true,
-                    AuthVerification: canAccessHackerPass,
-                  }),
-                  {
-                    redirAfterLogin: true,
-                    requiredAuthState: true,
-                    AuthVerification: (user: IAccount) =>
-                      user.confirmed && user.accountType === UserType.HACKER,
-                  }
+              component={withBackground(
+                withNavbar(
+                  withAuthRedirect(
+                    withHackerRedirect(HackPassPage, {
+                      requiredAuthState: true,
+                      AuthVerification: canAccessHackerPass,
+                    }),
+                    {
+                      redirAfterLogin: true,
+                      requiredAuthState: true,
+                      AuthVerification: (user: IAccount) =>
+                        user.confirmed && user.accountType === UserType.HACKER,
+                    }
+                  )
                 )
               )}
             />
             <Route
               exact={true}
               path={FrontendRoute.EDIT_SPONSOR_PAGE}
-              component={withNavbar(
-                withAuthRedirect(
-                  withSponsorRedirect(EditSponsorPage, {
-                    requiredAuthState: true,
-                  }),
-                  {
-                    redirAfterLogin: true,
-                    AuthVerification: (user: IAccount) =>
-                      user.confirmed && isSponsor(user),
-                  }
-                ),
-                { activePage: 'sponsor' }
+              component={withBackground(
+                withNavbar(
+                  withAuthRedirect(
+                    withSponsorRedirect(EditSponsorPage, {
+                      requiredAuthState: true,
+                    }),
+                    {
+                      redirAfterLogin: true,
+                      AuthVerification: (user: IAccount) =>
+                        user.confirmed && isSponsor(user),
+                    }
+                  ),
+                  { activePage: 'sponsor' }
+                )
               )}
             />
-            <Route path="*" component={withNavbar(ErrorPage)} />
+            <Route path="*" component={withBackground(withNavbar(ErrorPage))} />
           </Switch>
         </>
       </BrowserRouter>

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -163,4 +163,4 @@ export const SPONSOR_NOMINEE_LABEL = 'Nominees';
 export const SETTINGS_OPEN_TIME_LABEL = 'Applications open at:';
 export const SETTINGS_CLOSE_TIME_LABEL = 'Applications close at:';
 export const SETTINGS_CONFIRM_TIME_LABEL = 'Hacker confirmations close at:';
-export const SETTINGS_IS_REMOTE_LABEL = 'Hackathon is remote:';
+export const SETTINGS_IS_REMOTE_LABEL = 'Remote hackathon mode';

--- a/src/features/Dashboard/View.tsx
+++ b/src/features/Dashboard/View.tsx
@@ -1,9 +1,7 @@
 import { Box, Flex } from '@rebass/grid';
 import * as React from 'react';
-import MediaQuery from 'react-responsive';
 
 import {
-  BackgroundImage,
   Card,
   H1,
   H2,
@@ -11,7 +9,6 @@ import {
   LinkDuo,
 } from '../../shared/Elements';
 
-import BackgroundLandscape from '../../assets/images/backgroundLandscape.svg';
 import theme from '../../shared/Styles/theme';
 
 interface IDashboardView {
@@ -76,17 +73,6 @@ const DashboardView: React.SFC<IDashboardView> = ({
               </Card>
             </LinkDuo>
           ))}
-          <MediaQuery minWidth={960}>
-            <Box width={1}>
-              <BackgroundImage
-                src={BackgroundLandscape}
-                top={'0px'}
-                left={'0px'}
-                imgWidth={'100%'}
-                imgHeight={'100%'}
-              />
-            </Box>
-          </MediaQuery>
         </Flex>
       </Box>
     </Flex>

--- a/src/pages/Account/Confirm.tsx
+++ b/src/pages/Account/Confirm.tsx
@@ -6,6 +6,7 @@ import { Auth } from '../../api';
 import { getTokenFromQuery, HACKATHON_NAME } from '../../config';
 import {
   Button,
+  ButtonVariant,
   H1,
   Image,
   MaxWidthBox,
@@ -85,7 +86,7 @@ class ConfirmAccountPage extends React.Component<
         </MaxWidthBox>
         <MaxWidthBox hidden={this.state.attempting}>
           <Link to={link}>
-            <Button>{buttonMessage}</Button>
+            <Button variant={ButtonVariant.Primary}>{buttonMessage}</Button>
           </Link>
         </MaxWidthBox>
       </Flex>

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -1,62 +1,41 @@
-import { Box, Flex } from '@rebass/grid';
-import * as React from 'react';
+import React from 'react';
 import Helmet from 'react-helmet';
-import { RouteComponentProps, withRouter } from 'react-router';
 import { LinkDuo } from '../shared/Elements';
 
-import { HACKATHON_NAME } from '../config';
+import { FrontendRoute, HACKATHON_NAME } from '../config';
 
-import Construction from '../assets/images/construction-notfound.svg';
-
-import Button from '../shared/Elements/Button';
+import Button, { ButtonVariant } from '../shared/Elements/Button';
 import H1 from '../shared/Elements/H1';
-import Image from '../shared/Elements/Image';
-import MaxWidthBox from '../shared/Elements/MaxWidthBox';
 import Paragraph from '../shared/Elements/Paragraph';
+import { withRouter } from 'react-router';
 
 /**
  * Container that renders 404 not found page.
  */
-class NotFoundContainer extends React.Component<RouteComponentProps> {
-  public render() {
-    return (
-      <Flex
-        flexWrap={'wrap'}
-        justifyContent={'center'}
-        alignItems={'center'}
-        flexDirection={'column'}
-        px={3}
-      >
-        <Helmet>
-          <title>Page not found | {HACKATHON_NAME}</title>
-        </Helmet>
-        <Box>
-          <Image src={Construction} imgHeight={'7rem'} padding={'0rem'} />
-        </Box>
-        <Box>
-          <H1>404: Page not Found</H1>
-        </Box>
-        <MaxWidthBox fontSize={[2, 3, 4]}>
-          <Paragraph paddingBottom={'20px'} textAlign={'center'}>
-            The page you're looking for doesn't exist or has been moved
-          </Paragraph>
-        </MaxWidthBox>
-        <Box width={'100%'}>
-          <Flex
-            justifyContent={'center'}
-            alignItems={'center'}
-            flexDirection={'column'}
-          >
-            <Box>
-              <LinkDuo to={'/'}>
-                <Button type="button">Click to go home</Button>
-              </LinkDuo>
-            </Box>
-          </Flex>
-        </Box>
-      </Flex>
-    );
-  }
-}
+const NotFoundPage: React.FC = () => (
+  <>
+    <Helmet>
+      <title>Page not found | {HACKATHON_NAME}</title>
+    </Helmet>
 
-export default withRouter(NotFoundContainer);
+    <div className="container">
+      <H1 marginBottom="0">404: Page not found</H1>
+      <Paragraph>The page you're looking for doesn't exists or has been moved</Paragraph>
+
+      <LinkDuo to={FrontendRoute.HOME_PAGE}>
+        <Button type="button" variant={ButtonVariant.Secondary} isOutlined={true}>Click to go home</Button>
+      </LinkDuo>
+    </div>
+
+    <style jsx>{`
+      .container {
+        width: 440px;
+        margin: auto;
+        padding-top: 30px;
+        padding-bottom: 120px;
+      }
+    `}</style>
+  </>
+)
+
+export default withRouter(NotFoundPage);


### PR DESCRIPTION
### Tickets:

- HCK- #922 

### List of changes:

- Use withBackground() for sponsor and staff dashboard pages, removing old background image so cards are clickable again
- Redo 404 page
- Update a couple buttons that were missed to use new style 

### Type of change:

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How did you do this?

### How to test:

### Questions:

### PR Checklist:

- [X] Merged `develop` branch (before testing)
- [X] Linted my code locally
- [ ] Listed change(s) in the Changelog
- [X] Tested all links in project relevant browsers
- [X] Tested all links on different screen sizes
- [X] Referenced all useful info (issues, tasks, etc)

### Screenshots:
![image](https://user-images.githubusercontent.com/3229837/100394442-2ea0dd80-300b-11eb-92d5-2586eda54e95.png)
![image](https://user-images.githubusercontent.com/3229837/100394454-382a4580-300b-11eb-84a6-0af3f5f93450.png)
![image](https://user-images.githubusercontent.com/3229837/100394484-48dabb80-300b-11eb-9379-d2b94e99081b.png)

