### PR TITLE
fix: broken back button in renderPortfolioFormik

### DIFF
--- a/src/features/Application/ManageApplicationForm.tsx
+++ b/src/features/Application/ManageApplicationForm.tsx
@@ -266,7 +266,7 @@ const ManageApplicationForm: React.FC<IManageApplicationProps> = (props) => {
             disabled={true}
             variant={ButtonVariant.Secondary}
             isOutlined={true}
-            style={{ marginRight: '24px', display: 'none' }}
+            style={{ display: 'none' }}
           >
             Back
           </Button>

--- a/src/features/Application/ManageApplicationForm.tsx
+++ b/src/features/Application/ManageApplicationForm.tsx
@@ -261,6 +261,16 @@ const ManageApplicationForm: React.FC<IManageApplicationProps> = (props) => {
 
         <div className="buttons">
           <Button
+            type="reset"
+            isLoading={false}
+            disabled={true}
+            variant={ButtonVariant.Secondary}
+            isOutlined={true}
+            style={{ marginRight: '24px', display: 'none' }}
+          >
+            Back
+          </Button>
+          <Button
             type="submit"
             isLoading={isSubmitting}
             disabled={isSubmitting}
@@ -1194,7 +1204,6 @@ const ManageApplicationForm: React.FC<IManageApplicationProps> = (props) => {
     } else {
       setResume(resume || values.resume);
     }
-
     // Reset scroll to top of page
     window.scrollTo(0, 0);
   };

--- a/src/features/Application/ManageApplicationForm.tsx
+++ b/src/features/Application/ManageApplicationForm.tsx
@@ -321,7 +321,11 @@ const ManageApplicationForm: React.FC<IManageApplicationProps> = (props) => {
    */
   const renderPortfolioFormik = (fp: FormikProps<any>) => {
     return (
-      <Form onKeyDown={onKeyDown} onSubmit={fp.handleSubmit}>
+      <Form
+        onKeyDown={onKeyDown}
+        onSubmit={fp.handleSubmit}
+        onReset={fp.handleReset}
+      >
         <div className="container">
           <div className="fields">
             <H1 fontSize={'24px'} marginBottom={'40px'}>


### PR DESCRIPTION
### Tickets:

- HCK-#919 

### List of changes:

- Back button should work again without breaking next page in `renderEducationFormik()`

### Type of change:

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How did you do this?
- Added a placeholder reset button that is hidden through CSS
### How to test:

### Questions:

### PR Checklist:

- [x] Merged `develop` branch (before testing)
- [x] Linted my code locally
- [ ] Listed change(s) in the Changelog
- [x] Tested all links in project relevant browsers
- [x] Tested all links on different screen sizes
- [x] Referenced all useful info (issues, tasks, etc)

### Screenshots:

close #919 