### PR TITLE
Bug: Fix issue with font in select menu not matching input labels font.

### DIFF
--- a/src/shared/Form/Autosuggest.tsx
+++ b/src/shared/Form/Autosuggest.tsx
@@ -37,7 +37,6 @@ const AutosuggestWrapper = styled.div`
     overflow-y: auto;
     max-height: 200px;
     border: 1px solid ${(props) => props.theme.colors.black30};
-    font-family: 'Hind Siliguri', sans-serif;
     border-radius: 2px;
     z-index: 10;
   }

--- a/src/shared/Form/StyledCreatableSelect.tsx
+++ b/src/shared/Form/StyledCreatableSelect.tsx
@@ -4,7 +4,7 @@ import styled from '../Styles/styled-components';
 import { ITheme } from '../Styles/theme';
 
 export const StyledCreatableSelect = styled(CreatableSelect)`
-  font-family: ${(props) => props.theme.fonts.body};
+  font-family: ${(props) => props.theme.fonts.header};
 
   .react-select__control {
     ${inputStyles}


### PR DESCRIPTION
### Tickets:
*  HCK-#902 

### List of changes:
- Delete forced font 'Hind Siliguri' on autocomplete select menu.
- Change font on StyledCreatableSelect to match the header instead of the body.

### Type of change:
- [X] Bug fix (non-breaking change which fixes an issue)

### How to test:
- Find any select menu on any page and check if it's font matches with it's labels font.

### Questions:
- The font 'Hind Siliguri' was hard-coded on the autocomplete select menu so was it an intentional design decision?
- The header and body font themes are different. So again was the different font on the select menu an intentional design decision?

### PR Checklist
- [ ] Merged `develop` branch (before testing)
- [X] Linted my code locally
- [ ] Listed change(s) in the Changelog
- [X] Tested all links in project relevant browsers
- [X] Tested all links on different screen sizes
- [X] Referenced all useful info (issues, tasks, etc)

### Screenshots:
<img width="1440" alt="Screen Shot 2021-08-09 at 11 14 10 PM" src="https://user-images.githubusercontent.com/83686967/128803012-cd08fec3-6c81-4131-bb7e-0948cd2f7e4e.png">
<img width="1440" alt="Screen Shot 2021-08-09 at 11 14 22 PM" src="https://user-images.githubusercontent.com/83686967/128803016-19f1cbef-01bf-44ae-bfe5-d34610657751.png">
