### PR TITLE
fix: Removing button to access travel page

### DIFF
--- a/src/config/frontendRoutes.ts
+++ b/src/config/frontendRoutes.ts
@@ -19,7 +19,7 @@ export enum FrontendRoute {
   SPONSOR_SEARCH_PAGE = '/sponsor/search',
   SPONSOR_ONBOARDING_PAGE = '/sponsor/onboarding',
   TEAM_PAGE = '/team',
-  TRAVEL_PAGE = '/travel',
+  // TRAVEL_PAGE = '/travel',
 
   CREATE_SPONSOR_PAGE = '/sponsor/create',
   EDIT_SPONSOR_PAGE = '/sponsor/edit',

--- a/src/features/Status/StatusCTA.tsx
+++ b/src/features/Status/StatusCTA.tsx
@@ -95,13 +95,13 @@ const StatusCTA: React.FC<IStatusHeaderProps> = ({
       </Button>
     </LinkDuo>
   );
-  const travelButton = (
-    <LinkDuo to={FrontendRoute.TRAVEL_PAGE}>
-      <Button type="button" variant={ButtonVariant.Secondary}>
-        Travel
-      </Button>
-    </LinkDuo>
-  );
+  // const travelButton = (
+  //   <LinkDuo to={FrontendRoute.TRAVEL_PAGE}>
+  //     <Button type="button" variant={ButtonVariant.Secondary}>
+  //       Travel
+  //     </Button>
+  //   </LinkDuo>
+  // );
 
   // Possible choices for art
   const rocketArt = (
@@ -224,7 +224,7 @@ const StatusCTA: React.FC<IStatusHeaderProps> = ({
     case DetailedState.CONFIRMED:
       text = CONSTANTS.CONFIRMED_STATUS_TEXT;
       if (!settings.isRemote) {
-        buttons = [hackPassButton, travelButton, withdrawButton];
+        buttons = [hackPassButton, withdrawButton];
       } else {
         buttons = [hackPassButton, liveSiteButton, withdrawButton];
       }


### PR DESCRIPTION
### Tickets:

- HCK-

### List of changes:

- Remove left over button to access travel page. Commenting out everything travel related so doesn't happen again for the time being.

### Type of change:

Please delete options that aren't relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How did you do this?

### How to test:

### Questions:

### PR Checklist:

- [ ] Merged `develop` branch (before testing)
- [ ] Linted my code locally
- [ ] Listed change(s) in the Changelog
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links on different screen sizes
- [ ] Referenced all useful info (issues, tasks, etc)

### Screenshots:
