### PR TITLE
Replaced ability to "create" a major with "Other" option

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
     "start": "PORT=1337 react-app-rewired start",
     "start-windows": "set PORT=1337 && react-app-rewired start",
     "build": "PORT=1337 react-app-rewired build",
+    "build-windows": "set PORT=1337 && react-app-rewired build",
     "predeploy": "yarn build",
     "generate-barrels": "barrelsby --delete --exclude .*\\.test\\.tsx --directory ./src -l below -q",
     "test": "PORT=1337 react-scripts-ts test --env=jsdom",
+    "test-windows": "set PORT=1337 && react-scripts-ts test --env=jsdom",
     "eject": "PORT=1337 react-scripts-ts eject",
     "lint": "tslint --fix 'src/**/*.{ts,tsx}' --force"
   },

--- a/src/config/majors.ts
+++ b/src/config/majors.ts
@@ -91,6 +91,7 @@ const MajorsList = [
   'Theatre',
   'Urban Planning',
   'Urban Systems',
+  'Other'
 ];
 
 export const Majors = MajorsList.map((v) => ({ label: v, value: v }));

--- a/src/features/Application/ManageApplicationForm.tsx
+++ b/src/features/Application/ManageApplicationForm.tsx
@@ -255,7 +255,7 @@ const ManageApplicationForm: React.FunctionComponent<
               name={'hacker.application.general.fieldOfStudy'}
               options={Majors}
               isMulti={true}
-              creatable={true}
+              creatable={false}
               component={FormikElements.Select}
               label={CONSTANTS.FIELD_OF_STUDY_LABEL}
               placeholder={CONSTANTS.FIELD_OF_STUDY_PLACEHOLDER}


### PR DESCRIPTION
### List of changes:

- Added "Other" option to Field of Study Select in Hacker Application and removed the ability to create an option. 
- Added Windows-specific commands to the package.json. Not sure if build works.

### Type of change:

Please delete options that aren't relevant.

- [X] New feature (non-breaking change which adds functionality)

### How did you do this?
In majors.ts, added "Other" to the MajorsList.
In ManageApplicationForm.tsx, changed creatable={true} to creatable={false} for the Field of Study field.
In package.json, added Windows command "set" and && to "build" and "test". Not sure if build works.

### How to test:

### Questions:

### PR Checklist:

- [ ] Merged `develop` branch (before testing)
- [ ] Linted my code locally
- [ ] Listed change(s) in the Changelog
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links on different screen sizes
- [ ] Referenced all useful info (issues, tasks, etc)

### Screenshots:
![Screenshot 2024-10-28 180450](https://github.com/user-attachments/assets/2d0bf0f5-c2c9-4247-b424-bd299057ad39)
![Screenshot 2024-10-28 180409](https://github.com/user-attachments/assets/d8c1fbbf-39ed-4ba9-964b-6bc4ab2bac3f)
