### PR TITLE
Fix: Review application typo, outdated facebook popup, phone number field on account creation

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -143,7 +143,7 @@ export const TRAVEL_REQUEST_REASON_LABEL = 'Reason';
 export const PREVIOUS_HACKATHONS_LABEL =
   'How many hackathons have you been to?';
 export const REVIEW_APPLICIATION_DESCRIPTION =
-  'Your are about to submit. Please review your application before submitting. You won’t be able to edit your responses later.';
+  'You are about to submit. Please review your application before submitting. You won’t be able to edit your responses later.';
 
 // Invite Page
 export const ACCOUNT_TYPE_LABEL = 'Account type';

--- a/src/features/Account/ManageAccountForm.tsx
+++ b/src/features/Account/ManageAccountForm.tsx
@@ -281,18 +281,21 @@ const ManageAccountForm: React.FC<IManageAccountProps> = (props) => {
             name={'newPassword'}
           />
           <ErrorMessage component={FormikElements.Error} name="newPassword" />
-          <FastField
-            component={FormikElements.FormattedNumber}
-            label={CONSTANTS.PHONE_NUMBER_LABEL}
-            placeholder="+# (###) ###-####"
-            format="+# (###) ###-####"
-            name={'phoneNumber'}
-            required={true}
-            value={fp.values.phoneNumber}
-          />
-          <ErrorMessage component={FormikElements.Error} name="phoneNumber" />
         </>
       )}
+
+      <FastField
+        component={FormikElements.FormattedNumber}
+        label={CONSTANTS.PHONE_NUMBER_LABEL}
+        placeholder="+# (###) ###-####"
+        format="+# (###) ###-####"
+        name={'phoneNumber'}
+        required={true}
+        value={fp.values.phoneNumber}
+      />
+      <ErrorMessage component={FormikElements.Error} name="phoneNumber" />
+
+
       <FastField
         component={FormikElements.Select}
         creatable={true}

--- a/src/features/Application/ManageApplicationForm.tsx
+++ b/src/features/Application/ManageApplicationForm.tsx
@@ -1179,18 +1179,6 @@ const ManageApplicationForm: React.FunctionComponent<
               </GridTwoColumn>
             </>
           ) : null}
-
-          <div className="eventPrompt">
-            Make sure to mark yourself as going to our{' '}
-            <a
-              href={CONSTANTS.FACEBOOK_EVENT_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Facebook event
-            </a>
-            !
-          </div>
         </div>
 
         <div className="buttons">


### PR DESCRIPTION
### Tickets:

- HCK-

### List of changes:

- fixed review application typo 
- removed outdated facebook popup
- added phone number field on account creation

### Type of change:

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### How did you do this?

Changed some code

### How to test:

Check application review on dashboard. Check account creation field works and creates an account with a phone number Check if facebook popup appears/doesn't appear (shouldn't appear).

### Questions:

I only added the phone number element to the form because Tavi said there was a field for it in the db already. I'm assuming this is fine, please refer to the photo and check the change.

### PR Checklist:

- [ ] Merged `develop` branch (before testing)
- [ ] Linted my code locally
- [ ] Listed change(s) in the Changelog
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links on different screen sizes
- [ ] Referenced all useful info (issues, tasks, etc)

### Screenshots:

<img width="583" alt="image" src="https://github.com/user-attachments/assets/ff5822c2-1f19-43eb-bda2-288b1c659e82">

