### PR TITLE
display the number of hackers returned from a search query

### DIFF
--- a/src/features/Search/Search.tsx
+++ b/src/features/Search/Search.tsx
@@ -80,6 +80,7 @@ class SearchContainer extends React.Component<{}, ISearchState> {
           <Flex>
             <Box width={1 / 6} mx={2}>
               <H2>Filters</H2>
+              <h4>{this.state.results.length} results</h4>
               <FilterComponent
                 initFilters={query}
                 onChange={this.onFilterChange}


### PR DESCRIPTION
### Tickets:
#1034 

- HCK-
-

### List of changes:

- Show the number of people currently shown in the "search" field. 
 - Much easier to see number of people who applied as well as number of people checked in during the Saturday morning of mchacks.

### Type of change:

- [x] New feature (non-breaking change which adds functionality)

### How did you do this?

- Display length of results array in text

### How to test:
Make a search in the search page.

### Questions:

### PR Checklist:

- [ ] Merged `develop` branch (before testing)
- [ ] Linted my code locally
- [ ] Listed change(s) in the Changelog
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links on different screen sizes
- [ ] Referenced all useful info (issues, tasks, etc)

### Screenshots:
Number of results is shown under the "filters" header as shown here.
<img width="1439" height="765" alt="Screenshot 2025-10-27 at 13 21 44" src="https://github.com/user-attachments/assets/18a1d051-6ca8-46c3-bfa9-64ae3a12129e" />

