### PR TITLE
Multi Select Pronouns + Require Gender

### DIFF
--- a/src/config/genders.ts
+++ b/src/config/genders.ts
@@ -2,6 +2,7 @@ export enum Genders {
   FEMALE = 'Female',
   MALE = 'Male',
   NON_BINARY = 'Non-binary',
+  OTHER = 'Other (not listed)',
   NO_ANSWER = 'Prefer not to answer',
 }
 export default Genders;

--- a/src/config/userTypes.ts
+++ b/src/config/userTypes.ts
@@ -24,7 +24,7 @@ export interface IAccount {
   // The user's birthdate
   birthDate?: string;
   // The preferred pronoun
-  pronoun: string;
+  pronoun: String[];
   // The database id (if new, leave blank / make '')
   id: string;
   _id?: string;

--- a/src/features/Account/ManageAccountForm.tsx
+++ b/src/features/Account/ManageAccountForm.tsx
@@ -78,7 +78,7 @@ const ManageAccountForm: React.FC<IManageAccountProps> = (props) => {
     lastName: '',
     password: getNestedAttr(props, ['location', 'state', 'password']) || '',
     phoneNumber: '',
-    pronoun: '',
+    pronoun: [],
     gender: '',
     dietaryRestrictions: [],
   });
@@ -319,7 +319,6 @@ const ManageAccountForm: React.FC<IManageAccountProps> = (props) => {
         options={getOptionsFromEnum(Genders)}
         required={true}
         value={fp.values.gender}
-        showOptionalLabel={true}
       />
       <ErrorMessage component={FormikElements.Error} name="gender" />
       <FastField
@@ -327,9 +326,10 @@ const ManageAccountForm: React.FC<IManageAccountProps> = (props) => {
         creatable={true}
         label={CONSTANTS.PRONOUN_LABEL}
         name={'pronoun'}
+        isMulti={true}
         placeholder={CONSTANTS.PRONOUN_PLACEHOLDER}
         options={getOptionsFromEnum(Pronouns)}
-        required={true}
+        required={false}
         value={fp.values.pronoun}
         showOptionalLabel={true}
       />

--- a/src/features/Account/validationSchema.ts
+++ b/src/features/Account/validationSchema.ts
@@ -15,10 +15,10 @@ const getValidationSchema = (isCreate: boolean) => {
     email: string().required('Required').email('Must be a valid email'),
     password,
     newPassword: string().min(6, 'Must be at least 6 characters'),
-    pronoun: string(),
-    gender: string(),
+    pronoun: array().of(string()),
+    gender: string().required('Required'),
     dietaryRestrictions: array().of(string()),
-    phoneNumber: string().test(
+    phoneNumber: string().required('Required').test(
       'validPhone',
       'Must be a valid phone number',
       (value) => {

--- a/src/features/HackPass/Pass.tsx
+++ b/src/features/HackPass/Pass.tsx
@@ -16,7 +16,7 @@ export const Pass: React.FunctionComponent<IPassProps> = (
       <img src={props.qrData} className="qrCode" alt="" />
       <div className="info">
         <h2>{props.account.firstName}</h2>
-        <h3>{props.account.pronoun}</h3>
+        <h3>{props.account.pronoun.join(", ")}</h3>
         <h3>{props.hacker.application.general.school}</h3>
       </div>
     </div>

--- a/src/util/UserInfoHelperFunctions.tsx
+++ b/src/util/UserInfoHelperFunctions.tsx
@@ -298,7 +298,7 @@ export async function generateHackPass(
 
   if (account.pronoun) {
     doc.text('Hacker', 8, 15);
-    doc.text(account.pronoun, 8, 17);
+    doc.text(account.pronoun.join(", "), 8, 17);
   } else {
     doc.text('Hacker', 8, 16);
   }


### PR DESCRIPTION

### Tickets:

closes #1030 

- HCK-

### List of changes:

- Require the gender field at account creation (for better statistics). There is still a "prefer not to answer" option, so it is still essentially optional.
- Allow for multi-select of pronouns (see hackerAPI PR)
  - ex. someone uses she/they pronouns, they can now select both she/her and they/them options from the dropdown

### Type of change:

Please delete options that aren't relevant.

- [ ] New feature (non-breaking change which adds functionality)

### How did you do this?

### How to test:

### Questions:

### PR Checklist:

- [x] Merged `develop` branch (before testing)
- [ ] Linted my code locally
- [ ] Listed change(s) in the Changelog
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links on different screen sizes
- [ ] Referenced all useful info (issues, tasks, etc)

### Screenshots:
staff view
<img width="692" height="231" alt="Screenshot 2025-10-29 at 23 40 08" src="https://github.com/user-attachments/assets/39ab223b-6b29-4952-94f5-741c260dfd26" />

account creation form
<img width="491" height="133" alt="Screenshot 2025-10-29 at 23 40 44" src="https://github.com/user-attachments/assets/31588bc3-cbec-4825-9a1a-070b37d44e05" />

HackPass view
<img width="422" height="530" alt="Screenshot 2025-10-29 at 23 41 17" src="https://github.com/user-attachments/assets/53930241-5b56-4825-be7a-7307e0573f6a" />

